### PR TITLE
Brad dev

### DIFF
--- a/bin/aprsreceiver.py
+++ b/bin/aprsreceiver.py
@@ -35,7 +35,7 @@ import signal
 #    This is the process that listens on various frequencies
 ##################################################
 class aprs_receiver(gr.top_block):
-    def __init__(self, freqlist=[(144390000, 12000)], rtl=0):
+    def __init__(self, freqlist=[(144390000, 12000)], rtl=0, prefix="rtl"):
         gr.top_block.__init__(self, "APRS Receiver for Multiple Frequencies")
 
         ##################################################
@@ -43,7 +43,7 @@ class aprs_receiver(gr.top_block):
         ##################################################
         self.Frequencies = freqlist
         self.direwolf_audio_rate = 48000
-        self.rtl_id = "rtl=" + str(rtl)
+        self.rtl_id = prefix + "=" + str(rtl)
 
         ##################################################
         # Variables
@@ -101,13 +101,13 @@ class aprs_receiver(gr.top_block):
 # GRProcess:
 #    - Then starts up an instance of the aprs_receiver class
 ##################################################
-def GRProcess(flist=[(144390000, 12000)], rtl=0, e = None):
+def GRProcess(flist=[(144390000, 12000)], rtl=0, prefix="rtl", e = None):
     try:
 
         #print "GR [%d], listening on: " % rtl, flist
 
         # create an instance of the aprs receiver class
-        tb = aprs_receiver(freqlist=flist, rtl=rtl)
+        tb = aprs_receiver(freqlist=flist, rtl=rtl, prefix=prefix)
 
         # call its "run" method...this blocks until done
         tb.start()

--- a/bin/habtracker-daemon.py
+++ b/bin/habtracker-daemon.py
@@ -682,7 +682,7 @@ def main():
                 direwolfFreqList.append(freqlist)
 
                 # This is the GnuRadio process
-                grprocess = mp.Process(target=aprsreceiver.GRProcess, args=(freqlist, int(k["rtl"]), stopevent))
+                grprocess = mp.Process(target=aprsreceiver.GRProcess, args=(freqlist, int(k["rtl"]), k["prefix"], stopevent))
                 grprocess.daemon = True
                 grprocess.name = "GnuRadio_" + str(k["rtl"])
                 processes.append(grprocess)

--- a/bin/searchrtlsdr.py
+++ b/bin/searchrtlsdr.py
@@ -24,48 +24,49 @@ import usb.util
 
 # This list is from the librtlsdr and osmosdr projects. https://osmocom.org/projects/rtl-sdr/wiki/Rtl-sdr.
 known_devices = [
-    { "vendor": 0x0bda, "product": 0x2832, "description": "Generic RTL2832U" },
-    { "vendor": 0x0bda, "product": 0x2838, "description": "Generic RTL2832U OEM" },
-    { "vendor": 0x0413, "product": 0x6680, "description": "DigitalNow Quad DVB-T PCI-E card" },
-    { "vendor": 0x0413, "product": 0x6f0f, "description": "Leadtek WinFast DTV Dongle mini D" },
-    { "vendor": 0x0458, "product": 0x707f, "description": "Genius TVGo DVB-T03 USB dongle (Ver. B)" },
-    { "vendor": 0x0ccd, "product": 0x00a9, "description": "Terratec Cinergy T Stick Black (rev 1)" },
-    { "vendor": 0x0ccd, "product": 0x00b3, "description": "Terratec NOXON DAB/DAB+ USB dongle (rev 1)" },
-    { "vendor": 0x0ccd, "product": 0x00b4, "description": "Terratec Deutschlandradio DAB Stick" },
-    { "vendor": 0x0ccd, "product": 0x00b5, "description": "Terratec NOXON DAB Stick - Radio Energy" },
-    { "vendor": 0x0ccd, "product": 0x00b7, "description": "Terratec Media Broadcast DAB Stick" },
-    { "vendor": 0x0ccd, "product": 0x00b8, "description": "Terratec BR DAB Stick" },
-    { "vendor": 0x0ccd, "product": 0x00b9, "description": "Terratec WDR DAB Stick" },
-    { "vendor": 0x0ccd, "product": 0x00c0, "description": "Terratec MuellerVerlag DAB Stick" },
-    { "vendor": 0x0ccd, "product": 0x00c6, "description": "Terratec Fraunhofer DAB Stick" },
-    { "vendor": 0x0ccd, "product": 0x00d3, "description": "Terratec Cinergy T Stick RC (Rev.3)" },
-    { "vendor": 0x0ccd, "product": 0x00d7, "description": "Terratec T Stick PLUS" },
-    { "vendor": 0x0ccd, "product": 0x00e0, "description": "Terratec NOXON DAB/DAB+ USB dongle (rev 2)" },
-    { "vendor": 0x1554, "product": 0x5020, "description": "PixelView PV-DT235U(RN)" },
-    { "vendor": 0x15f4, "product": 0x0131, "description": "Astrometa DVB-T/DVB-T2" },
-    { "vendor": 0x15f4, "product": 0x0133, "description": "HanfTek DAB+FM+DVB-T" },
-    { "vendor": 0x185b, "product": 0x0620, "description": "Compro Videomate U620F"},
-    { "vendor": 0x185b, "product": 0x0650, "description": "Compro Videomate U650F"},
-    { "vendor": 0x185b, "product": 0x0680, "description": "Compro Videomate U680F"},
-    { "vendor": 0x1b80, "product": 0xd393, "description": "GIGABYTE GT-U7300" },
-    { "vendor": 0x1b80, "product": 0xd394, "description": "DIKOM USB-DVBT HD" },
-    { "vendor": 0x1b80, "product": 0xd395, "description": "Peak 102569AGPK" },
-    { "vendor": 0x1b80, "product": 0xd397, "description": "KWorld KW-UB450-T USB DVB-T Pico TV" },
-    { "vendor": 0x1b80, "product": 0xd398, "description": "Zaapa ZT-MINDVBZP" },
-    { "vendor": 0x1b80, "product": 0xd39d, "description": "SVEON STV20 DVB-T USB & FM" },
-    { "vendor": 0x1b80, "product": 0xd3a4, "description": "Twintech UT-40" },
-    { "vendor": 0x1b80, "product": 0xd3a8, "description": "ASUS U3100MINI_PLUS_V2" },
-    { "vendor": 0x1b80, "product": 0xd3af, "description": "SVEON STV27 DVB-T USB & FM" },
-    { "vendor": 0x1b80, "product": 0xd3b0, "description": "SVEON STV21 DVB-T USB & FM" },
-    { "vendor": 0x1d19, "product": 0x1101, "description": "Dexatek DK DVB-T Dongle (Logilink VG0002A)" },
-    { "vendor": 0x1d19, "product": 0x1102, "description": "Dexatek DK DVB-T Dongle (MSI DigiVox mini II V3.0)" },
-    { "vendor": 0x1d19, "product": 0x1103, "description": "Dexatek Technology Ltd. DK 5217 DVB-T Dongle" },
-    { "vendor": 0x1d19, "product": 0x1104, "description": "MSI DigiVox Micro HD" },
-    { "vendor": 0x1f4d, "product": 0xa803, "description": "Sweex DVB-T USB" },
-    { "vendor": 0x1f4d, "product": 0xb803, "description": "GTek T803" },
-    { "vendor": 0x1f4d, "product": 0xc803, "description": "Lifeview LV5TDeluxe" },
-    { "vendor": 0x1f4d, "product": 0xd286, "description": "MyGica TD312" },
-    { "vendor": 0x1f4d, "product": 0xd803, "description": "PROlectrix DV107669" }
+    { "vendor": 0x0bda, "product": 0x2832, "prefix":"rtl", "description": "Generic RTL2832U" },
+    { "vendor": 0x0bda, "product": 0x2838, "prefix":"rtl", "description": "Generic RTL2832U OEM" },
+    { "vendor": 0x0413, "product": 0x6680, "prefix":"rtl", "description": "DigitalNow Quad DVB-T PCI-E card" },
+    { "vendor": 0x0413, "product": 0x6f0f, "prefix":"rtl", "description": "Leadtek WinFast DTV Dongle mini D" },
+    { "vendor": 0x0458, "product": 0x707f, "prefix":"rtl", "description": "Genius TVGo DVB-T03 USB dongle (Ver. B)" },
+    { "vendor": 0x0ccd, "product": 0x00a9, "prefix":"rtl", "description": "Terratec Cinergy T Stick Black (rev 1)" },
+    { "vendor": 0x0ccd, "product": 0x00b3, "prefix":"rtl", "description": "Terratec NOXON DAB/DAB+ USB dongle (rev 1)" },
+    { "vendor": 0x0ccd, "product": 0x00b4, "prefix":"rtl", "description": "Terratec Deutschlandradio DAB Stick" },
+    { "vendor": 0x0ccd, "product": 0x00b5, "prefix":"rtl", "description": "Terratec NOXON DAB Stick - Radio Energy" },
+    { "vendor": 0x0ccd, "product": 0x00b7, "prefix":"rtl", "description": "Terratec Media Broadcast DAB Stick" },
+    { "vendor": 0x0ccd, "product": 0x00b8, "prefix":"rtl", "description": "Terratec BR DAB Stick" },
+    { "vendor": 0x0ccd, "product": 0x00b9, "prefix":"rtl", "description": "Terratec WDR DAB Stick" },
+    { "vendor": 0x0ccd, "product": 0x00c0, "prefix":"rtl", "description": "Terratec MuellerVerlag DAB Stick" },
+    { "vendor": 0x0ccd, "product": 0x00c6, "prefix":"rtl", "description": "Terratec Fraunhofer DAB Stick" },
+    { "vendor": 0x0ccd, "product": 0x00d3, "prefix":"rtl", "description": "Terratec Cinergy T Stick RC (Rev.3)" },
+    { "vendor": 0x0ccd, "product": 0x00d7, "prefix":"rtl", "description": "Terratec T Stick PLUS" },
+    { "vendor": 0x0ccd, "product": 0x00e0, "prefix":"rtl", "description": "Terratec NOXON DAB/DAB+ USB dongle (rev 2)" },
+    { "vendor": 0x1554, "product": 0x5020, "prefix":"rtl", "description": "PixelView PV-DT235U(RN)" },
+    { "vendor": 0x15f4, "product": 0x0131, "prefix":"rtl", "description": "Astrometa DVB-T/DVB-T2" },
+    { "vendor": 0x15f4, "product": 0x0133, "prefix":"rtl", "description": "HanfTek DAB+FM+DVB-T" },
+    { "vendor": 0x185b, "product": 0x0620, "prefix":"rtl", "description": "Compro Videomate U620F"},
+    { "vendor": 0x185b, "product": 0x0650, "prefix":"rtl", "description": "Compro Videomate U650F"},
+    { "vendor": 0x185b, "product": 0x0680, "prefix":"rtl", "description": "Compro Videomate U680F"},
+    { "vendor": 0x1b80, "product": 0xd393, "prefix":"rtl", "description": "GIGABYTE GT-U7300" },
+    { "vendor": 0x1b80, "product": 0xd394, "prefix":"rtl", "description": "DIKOM USB-DVBT HD" },
+    { "vendor": 0x1b80, "product": 0xd395, "prefix":"rtl", "description": "Peak 102569AGPK" },
+    { "vendor": 0x1b80, "product": 0xd397, "prefix":"rtl", "description": "KWorld KW-UB450-T USB DVB-T Pico TV" },
+    { "vendor": 0x1b80, "product": 0xd398, "prefix":"rtl", "description": "Zaapa ZT-MINDVBZP" },
+    { "vendor": 0x1b80, "product": 0xd39d, "prefix":"rtl", "description": "SVEON STV20 DVB-T USB & FM" },
+    { "vendor": 0x1b80, "product": 0xd3a4, "prefix":"rtl", "description": "Twintech UT-40" },
+    { "vendor": 0x1b80, "product": 0xd3a8, "prefix":"rtl", "description": "ASUS U3100MINI_PLUS_V2" },
+    { "vendor": 0x1b80, "product": 0xd3af, "prefix":"rtl", "description": "SVEON STV27 DVB-T USB & FM" },
+    { "vendor": 0x1b80, "product": 0xd3b0, "prefix":"rtl", "description": "SVEON STV21 DVB-T USB & FM" },
+    { "vendor": 0x1d19, "product": 0x1101, "prefix":"rtl", "description": "Dexatek DK DVB-T Dongle (Logilink VG0002A)" },
+    { "vendor": 0x1d19, "product": 0x1102, "prefix":"rtl", "description": "Dexatek DK DVB-T Dongle (MSI DigiVox mini II V3.0)" },
+    { "vendor": 0x1d19, "product": 0x1103, "prefix":"rtl", "description": "Dexatek Technology Ltd. DK 5217 DVB-T Dongle" },
+    { "vendor": 0x1d19, "product": 0x1104, "prefix":"rtl", "description": "MSI DigiVox Micro HD" },
+    { "vendor": 0x1f4d, "product": 0xa803, "prefix":"rtl", "description": "Sweex DVB-T USB" },
+    { "vendor": 0x1f4d, "product": 0xb803, "prefix":"rtl", "description": "GTek T803" },
+    { "vendor": 0x1f4d, "product": 0xc803, "prefix":"rtl", "description": "Lifeview LV5TDeluxe" },
+    { "vendor": 0x1f4d, "product": 0xd286, "prefix":"rtl", "description": "MyGica TD312" },
+    { "vendor": 0x1f4d, "product": 0xd803, "prefix":"rtl", "description": "PROlectrix DV107669" },
+    { "vendor": 0x1d50, "product": 0x6089, "prefix": "hackrf", "description": "OpenMoko, Inc. Great Scott Gadgets HackRF One SDR" },
 ]
 
 def getUSBDevices():
@@ -100,9 +101,9 @@ def getUSBDevices():
                 s = s if s else ""
                 p = p if p else ""
                 m = m if m else ""
-                
+
                 # Create a dict for this device
-                rtl = { "rtl" : i, "manufacturer" : m, "product" : p, "serialnumber" : s, "description" : sdr["description"]}
+                rtl = { "rtl" : i, "manufacturer" : m, "product" : p, "serialnumber" : s, "description" : sdr["description"], "prefix" : sdr["prefix"]}
 
                 # Check if the RTLSDR is using a serial number string that contains "adsb".
                 #     The idea being, not to use any SDR attached that is to be used for ADS-B reception instead.


### PR DESCRIPTION
To add support for the HackRF One, we have to use a different prefix when opening the device. All the other known devices use "rtl" but the HackRF needs "hackrf". I added a "prefix" key to the dict of known SDRs and then pass that value down the call-chain to where it is needed.