### PR TITLE
Automatically download missing packets from track.eoss.org

### DIFF
--- a/www/common/map.js
+++ b/www/common/map.js
@@ -51,6 +51,7 @@
     var lastposition;
     var activeflights = [];
     var globalUpdateCounter = 0;
+    var syncPacketsCounter = 0;
     var updateTimeout;
     var sidebar;
     var layerControl;
@@ -3137,6 +3138,22 @@ function getTrackers() {
         
 
     /************
+     * syncPackets
+     *
+     * This function will call the "syncpackets.php" file on the local system in an attempt
+     * to download any missing packets.
+    *************/
+    function syncPackets() {
+
+        // The URL for synchronizing packets with track.eoss.org.
+        var url = "syncpackets.php";
+
+        $.get(url, function(data) {
+        });
+    }
+
+
+    /************
      * UpdateAllItems
      *
      * This function updates other parts of the instrumentation, charts, and tables.
@@ -3165,12 +3182,23 @@ function getTrackers() {
             // Set updateAllItems to run again in 5 seconds, but as a full.
             updateTimeout = setTimeout(function() {updateAllItems("full")}, 5000);
             globalUpdateCounter = 0;
+
+            // Update the packet syncup counter
+            syncPacketsCounter += 1;
         }
         else {
             // Set updateAllItems to run again in 5 seconds.
             updateTimeout = setTimeout(updateAllItems, 5000);
         }
         globalUpdateCounter += 1;
+
+
+        // if it's been longer than ~5mins, then try to syncup packets with track.eoss.org
+        if (syncPacketsCounter > 2) {
+            // sync up packets and reset counter back to zero
+            syncPackets();
+            syncPacketsCounter = 0;
+        }
 
     }
 

--- a/www/getpackethashes.php
+++ b/www/getpackethashes.php
@@ -88,7 +88,7 @@
 
     if (sql_num_rows($result) > 0) {
         $data = sql_fetch_all($result)[0]["output"];
-        if (is_array($data)) {
+        if ($data) {
             if (count($data) > 0)
                 printf ("%s", sql_fetch_all($result)[0]["output"]);
             else

--- a/www/getpackethashes.php
+++ b/www/getpackethashes.php
@@ -1,0 +1,101 @@
+<?php
+/*
+*
+##################################################
+#    This file is part of the HABTracker project for tracking high altitude balloons.
+#
+#    Copyright (C) 2019,2020,2021 Jeff Deaton (N6BA)
+#
+#    HABTracker is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    HABTracker is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with HABTracker.  If not, see <https://www.gnu.org/licenses/>.
+#
+##################################################
+*
+ */
+
+
+    header("Content-Type:  application/json;");
+    session_start();
+    if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
+        $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
+    else
+        $documentroot = $_SERVER["DOCUMENT_ROOT"];
+    include $documentroot . '/common/functions.php';
+
+    $config = readconfiguration();
+
+    $formerror = false;
+    
+    ## Connect to the database
+    $link = connect_to_database();
+    if (!$link) {
+        printf ("[]");
+        //db_error(sql_last_error());
+        return 0;
+    }
+
+    ## query the last packets from stations...
+    $query = "
+        select 
+        array_to_json(array_agg(r)) as output
+
+        from 
+        (
+            select
+            a.tm,
+            a.callsign,
+            a.hash
+
+            from 
+            packets a,
+            flights f,
+            flightmap fm
+
+            where 
+            a.tm > now()::date
+            and a.tm > (now() - (to_char(($1)::interval, 'HH24:MI:SS'))::time)
+            and a.raw != ''
+            and fm.flightid = f.flightid
+            and a.callsign = fm.callsign
+            and f.active = 'y'
+   
+            order by
+            a.tm,
+            a.callsign
+        ) as r
+   ;"; 
+
+    $result = pg_query_params($link, $query, array(
+        sql_escape_string($config["lookbackperiod"] . " minute")
+    ));
+
+    if (!$result) {
+        printf("[]");
+        //db_error(sql_last_error());
+        sql_close($link);
+        return 0;
+    }
+
+    if (sql_num_rows($result) > 0) {
+        $data = sql_fetch_all($result)[0]["output"];
+        if (count($data) > 0)
+            printf ("%s", sql_fetch_all($result)[0]["output"]);
+        else
+            printf("[]");
+    }
+    else
+        printf ("[]");
+
+    sql_close($link);
+
+?>

--- a/www/getpackethashes.php
+++ b/www/getpackethashes.php
@@ -88,10 +88,14 @@
 
     if (sql_num_rows($result) > 0) {
         $data = sql_fetch_all($result)[0]["output"];
-        if (count($data) > 0)
-            printf ("%s", sql_fetch_all($result)[0]["output"]);
+        if (is_array($data)) {
+            if (count($data) > 0)
+                printf ("%s", sql_fetch_all($result)[0]["output"]);
+            else
+                printf("[]");
+        }
         else
-            printf("[]");
+            printf ("[]");
     }
     else
         printf ("[]");

--- a/www/getpackethashes.php
+++ b/www/getpackethashes.php
@@ -88,14 +88,10 @@
 
     if (sql_num_rows($result) > 0) {
         $data = sql_fetch_all($result)[0]["output"];
-        if ($data) {
-            if (count($data) > 0)
-                printf ("%s", sql_fetch_all($result)[0]["output"]);
-            else
-                printf("[]");
-        }
+        if ($data) 
+            printf ("%s", $data);
         else
-            printf ("[]");
+            printf("[]");
     }
     else
         printf ("[]");

--- a/www/getpackets.php
+++ b/www/getpackets.php
@@ -100,14 +100,10 @@
 
     if (sql_num_rows($result) > 0) {
         $data = sql_fetch_all($result)[0]["output"];
-        if ($data) {
-            if (count($data) > 0)
-                printf ("%s", sql_fetch_all($result)[0]["output"]);
-            else
-                printf("[]");
-        }
+        if ($data) 
+            printf ("%s", $data);
         else
-            printf ("[]");
+            printf("[]");
     }
     else
         printf ("[]");

--- a/www/getpackets.php
+++ b/www/getpackets.php
@@ -100,10 +100,14 @@
 
     if (sql_num_rows($result) > 0) {
         $data = sql_fetch_all($result)[0]["output"];
-        if (count($data) > 0)
-            printf ("%s", sql_fetch_all($result)[0]["output"]);
+        if (is_array($data)) {
+            if (count($data) > 0)
+                printf ("%s", sql_fetch_all($result)[0]["output"]);
+            else
+                printf("[]");
+        }
         else
-            printf("[]");
+            printf ("[]");
     }
     else
         printf ("[]");

--- a/www/getpackets.php
+++ b/www/getpackets.php
@@ -100,7 +100,7 @@
 
     if (sql_num_rows($result) > 0) {
         $data = sql_fetch_all($result)[0]["output"];
-        if (is_array($data)) {
+        if ($data) {
             if (count($data) > 0)
                 printf ("%s", sql_fetch_all($result)[0]["output"]);
             else

--- a/www/syncpackets.php
+++ b/www/syncpackets.php
@@ -70,6 +70,12 @@ function getPacketData($packets_url) {
         return 0;
     }
 
+    # Make sure the returned data is an array...we're expecting an array of packets to be returned.
+    if (!is_array($jsondata)) {
+        printf ("{\"result\": 0, \"packets\": 0, \"error\": \"Invalid data returned from track.eoss.org: %s\"}", json_last_error_msg());
+        return 0;
+    }
+
 
     if (count($jsondata) > 0) {
 
@@ -235,6 +241,11 @@ function checkPacketData($hashurl) {
         return 0;
     }
 
+    # Make sure the returned data is an array...we're expecting an array of packets to be returned.
+    if (!is_array($jsondata)) {
+        printf ("{\"result\": 0, \"packets\": 0, \"error\": \"Invalid data returned from track.eoss.org: %s\"}", json_last_error_msg());
+        return 0;
+    }
 
     if (count($jsondata) > 0) {
 
@@ -242,7 +253,6 @@ function checkPacketData($hashurl) {
         $link = connect_to_database();
         if (!$link) {
             printf ("{\"result\": 0, \"packets\": 0, \"error\": %s}", json_encode("Unable to connect to the backend database: " . sql_last_error()));
-            sql_close($link);
             return 0;
         }
 
@@ -314,6 +324,9 @@ function checkPacketData($hashurl) {
             return 0;
         }
 
+        # Close the database connection
+        sql_close($link);
+
         return sql_num_rows($check_result);
 
     }
@@ -343,23 +356,12 @@ function checkPacketData($hashurl) {
     }
 
     # Determine if there are packets missing
-    #printf ("Checking packets\n");
     $ret = checkPacketData($hashes_url);
-    #printf ("return code:  %d\n", $ret);
-
 
     # if there are packets missing then download the full data and update this database
     if ($ret)  {
-        #printf ("calling getPacketData\n");
         $r = getPacketData($fullpackets_url);
-        #printf ("getPacketData returned: %d\n", $r);
     }
-    else {
-        printf ("{\"result\": 0, \"packets\": 0, \"error\": \"No packets found or database is already up to date.\"}");
-    }
-
-    # close the database connection
-    sql_close($link);
 
 ?>
 


### PR DESCRIPTION
When the map page is open, it will attempt to connect to https://track.eoss.org/getpackethashes.php every 5 mins and compare returned values with what already exists in the local database.  If there are packets from an active flight that are missing from the local system, then try to connect to https://track.eoss.org/getpackets.php to download the full packet list entry and add missing ones to the local database.  If any of these web-connections fail, then just continue on unabated.  

The general idea is that if a user’s brick is connected to the internet, then the map screen will periodically check if the local system has all the packets for a given flight (more packets from a flight allows for more accurate landing predictions).  The prior mechanism for checking was to manually click the “Get Missing Packets...” button on the setup page.  One can still do that, but if the map page is open, then it will automatically perform that check every 5 mins.

One obvious use case for this is for those systems that are mobile, with intermittent Internet connectivity (i.e. phone hot spot).