### PR TITLE
Pause JavaScript on web pages that are not in focus for mobile/tablet devices

### DIFF
--- a/www/about.php
+++ b/www/about.php
@@ -35,6 +35,8 @@ include $documentroot . '/common/header.php';
 
 ?>
 <script>
+    var interval;
+
     /***********
     * updateMapLink
     *
@@ -63,10 +65,49 @@ include $documentroot . '/common/header.php';
             updateMapLink();
         }, 10);
 
-        setInterval (function() {
+        window.onfocus = gainFocus;
+        window.onblur = lostFocus;
+
+        interval = setInterval (function() {
             updateMapLink();
         }, 5000);
     });
+
+    /***********
+    * lostFocus
+    *
+    * This function is called when the browser tab loses focus
+    ***********/
+    function lostFocus() {
+        var isiPad = (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 0) || navigator.platform === 'iPad';
+        var isMobile = 'ontouchstart' in document.documentElement ||  navigator.maxTouchPoints > 1;
+
+        // If this is a mobile device then stop periodic updates...at least until the browser tab is in focus again.
+        if ((isiPad || isMobile) && interval) {
+            clearInterval(interval);
+        }
+
+        return 0;
+    }
+
+
+    /***********
+    * gainFocus
+    *
+    * This function is called when the browser tab regains focus
+    ***********/
+    function gainFocus() {
+
+        // if we're regaining focus, then restart periodic page updates.
+        if (interval) {
+            clearInterval(interval);
+            interval = setInterval (function() {
+                updateMapLink();
+            }, 5000);
+        }
+        return 0;
+    }
+
 </script>
 <div style="width: 90%;"> 
     <p class="header">

--- a/www/common/dashboard.js
+++ b/www/common/dashboard.js
@@ -26,6 +26,7 @@
     var lastStation = "";
     var lastStationTime = new Date(1970, 1, 1, 0, 0, 0, 0);
     var currentflight = "";
+    var interval;
 
     // The audio device
     var audio;
@@ -203,13 +204,15 @@
 
         // Get initial data
         getFlights();
-       //getrecentdata();
+        
+        // Stop processing on mobile devices when this browser tab loses focus.
+        window.onfocus = gainFocus;
+        window.onblur = lostFocus;
 
         // Set a timer so that we refresh data every 5 secs
-        setInterval(function() {
+        interval = setInterval(function() {
           getrecentdata(); 
           getAudioAlerts();
-          //processSoundQueue();
         }, 5000);
     });
 
@@ -532,5 +535,40 @@
 
 
 
+    /***********
+    * lostFocus
+    *
+    * This function is called when the browser tab loses focus
+    ***********/
+    function lostFocus() {
+        var isiPad = (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 0) || navigator.platform === 'iPad';
+        var isMobile = 'ontouchstart' in document.documentElement ||  navigator.maxTouchPoints > 1;
+
+        // If this is a mobile device then stop periodic updates...at least until the browser tab is in focus again.
+        if ((isiPad || isMobile) && interval) {
+            clearInterval(interval);
+        }
+
+        return 0;
+    }
+
+
+    /***********
+    * gainFocus
+    *
+    * This function is called when the browser tab regains focus
+    ***********/
+    function gainFocus() {
+
+        // if we're regaining focus, then restart periodic page updates.
+        if (interval) {
+            clearInterval(interval);
+            interval = setInterval(function() {
+              getrecentdata(); 
+              getAudioAlerts();
+            }, 5000);
+        }
+        return 0;
+    }
 
 

--- a/www/common/index.js
+++ b/www/common/index.js
@@ -24,6 +24,7 @@
 
 var numProcessesRunning = 0;
 var processInTransition = 0;
+var interval;
 
 /***********
 * escapeHtml
@@ -316,17 +317,58 @@ function updateMapLink() {
 
 
 /***********
+* lostFocus
+*
+* This function is called when the browser tab loses focus
+***********/
+function lostFocus() {
+    var isiPad = (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 0) || navigator.platform === 'iPad';
+    var isMobile = 'ontouchstart' in document.documentElement ||  navigator.maxTouchPoints > 1;
+
+    // If this is a mobile device then stop periodic updates...at least until the browser tab is in focus again.
+    if ((isiPad || isMobile) && interval) {
+        clearInterval(interval);
+    }
+
+    return 0;
+}
+
+
+/***********
+* gainFocus
+*
+* This function is called when the browser tab regains focus
+***********/
+function gainFocus() {
+    // if we're regaining focus, then restart periodic page updates.
+    if (interval) {
+        clearInterval(interval);
+        interval = setInterval(function() {
+            updateMapLink();
+            getrecentdata();
+            getgps();
+            getConfiguration();
+        }, 5000);
+    }
+    return 0;
+}
+
+
+/***********
 * ready
 *
 * This function is only called once the web page is fully loaded.
 ***********/
 $(document).ready(function () {
 
+    window.onfocus = gainFocus;
+    window.onblur = lostFocus;
+
     updateMapLink();
     getrecentdata();
     getConfiguration();
     getgps();
-    setInterval(function() {
+    interval = setInterval(function() {
         updateMapLink();
         getrecentdata();
         getgps();

--- a/www/common/map.js
+++ b/www/common/map.js
@@ -2083,17 +2083,13 @@ function getTrackers() {
         setTimeout(function() { getTrackers(); }, 40);
 
         // Update all things on the map.  Note:  updateAllItems will schedule itself to run every 5 seconds.  No need for a setInterval call.
-        // We delay a couple of seconds before updating the full map/gauges/tables if the number of flights/beacons we're tracking is > 8 in an attempt
-        // to not swamp the user's browser with updates upon first load.
-        //if (realtimeflightlayers.length > 8)
-        //    setTimeout(function() {updateAllItems("full")}, 5000);
-        //else
-        setTimeout(function() {updateAllItems("notfull");}, 5000); 
+        if (updateTimeout)
+            clearTimeout(updateTimeout);
+        updateTimeout = setTimeout(function() {updateAllItems("notfull");}, 5000); 
 
-        // When this map screen loses focus and then the user returns...when we regain focus, we want to update all items on the map.
-        //$(window).on('focus', function() { 
-        //    updateAllItems("full", true);
-        //});
+        // When this map screen loses focus and then the user returns...
+        window.onfocus = gainFocus;
+        window.onblur = lostFocus;
 
         // Get the latest position from GPS
         $.get("getposition.php", function(data) { 
@@ -3142,7 +3138,7 @@ function getTrackers() {
      * This function updates other parts of the instrumentation, charts, and tables.
      * This will update every chart/graph/table globally.
     *************/
-    function updateAllItems(fullupdate, fromFocus) {
+    function updateAllItems(fullupdate) {
 
         // Update process status
         setTimeout(function() { getProcessStatus(); }, 20);
@@ -3163,14 +3159,51 @@ function getTrackers() {
         // ...the idea being that ever so often, we should try a special update
         if (globalUpdateCounter > 20) {
             // Set updateAllItems to run again in 5 seconds, but as a full.
+            if (updateTimeout)
+                clearTimeout(updateTimeout);
             updateTimeout = setTimeout(function() {updateAllItems("full")}, 5000);
             globalUpdateCounter = 0;
         }
         else {
             // Set updateAllItems to run again in 5 seconds.
+            if (updateTimeout)
+                clearTimeout(updateTimeout);
             updateTimeout = setTimeout(updateAllItems, 5000);
         }
         globalUpdateCounter += 1;
 
     }
 
+/***********
+* lostFocus
+*
+* This function is called when the browser tab loses focus
+***********/
+function lostFocus() {
+    var isiPad = (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 0) || navigator.platform === 'iPad';
+    var isMobile = 'ontouchstart' in document.documentElement ||  navigator.maxTouchPoints > 1;
+
+    // If this is a mobile device then stop periodic updates...at least until the browser tab is in focus again.
+    if ((isiPad || isMobile) && updateTimeout) {
+        clearTimeout(updateTimeout);
+    }
+
+    return 0;
+}
+
+
+/***********
+* gainFocus
+*
+* This function is called when the browser tab regains focus
+***********/
+function gainFocus() {
+
+    // if we're regaining focus, then restart periodic page updates.
+    if (updateTimeout) {
+        var priorTimeout = updateTimeout;
+        clearTimeout(updateTimeout);
+        updateTimeout = setTimeout(updateAllItems, 5000);
+    }
+    return 0;
+}

--- a/www/common/rawdata.js
+++ b/www/common/rawdata.js
@@ -38,6 +38,9 @@
     var packetcount;
     var lastUpdateTime = 0;
 
+    // The interval timer
+    var interval;
+
     // Initial chart size
     var chartwidth = getChartWidth();
     var chartheight = getChartHeight();
@@ -1037,17 +1040,58 @@
 
         }, false);
 
+        window.onfocus = gainFocus;
+        window.onblur = lostFocus;
+
         // Create a timer that is called every 5secs for updating all of our items on the page
-        setInterval(function() { 
+        interval = setInterval(function() { 
             updateMapLink();
             getrecentdata(); 
             getchartdata(updatechart, "getaltitudechartdata.php"); 
             getchartdata(updatechart2, "getairdensity.php"); 
             getchartdata(updatechart3, "getdirewolfperformance.php"); 
             getchartdata2(updatechart4, "gettemppressure.php"); 
-            //getdigidata();
-            //gettrackerdata();
         }, 5000);
     }
 
+
+/***********
+* lostFocus
+*
+* This function is called when the browser tab loses focus
+***********/
+function lostFocus() {
+    var isiPad = (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 0) || navigator.platform === 'iPad';
+    var isMobile = 'ontouchstart' in document.documentElement ||  navigator.maxTouchPoints > 1;
+
+    // If this is a mobile device then stop periodic updates...at least until the browser tab is in focus again.
+    if ((isiPad || isMobile) && interval) {
+        clearInterval(interval);
+    }
+
+    return 0;
+}
+
+
+/***********
+* gainFocus
+*
+* This function is called when the browser tab regains focus
+***********/
+function gainFocus() {
+
+    // if we're regaining focus, then restart periodic page updates.
+    if (interval) {
+        clearInterval(interval);
+        interval = setInterval(function() { 
+            updateMapLink();
+            getrecentdata(); 
+            getchartdata(updatechart, "getaltitudechartdata.php"); 
+            getchartdata(updatechart2, "getairdensity.php"); 
+            getchartdata(updatechart3, "getdirewolfperformance.php"); 
+            getchartdata2(updatechart4, "gettemppressure.php"); 
+        }, 5000);
+    }
+    return 0;
+}
 

--- a/www/index.php
+++ b/www/index.php
@@ -36,6 +36,7 @@ include $documentroot . '/common/header.php';
 ?>
 <script src="/common/index.js"></script>
 <div>
+    <div id="error" style="margin-left: 10px; color: white;"></div>
     <p class="header">
         <img class="bluesquare"  src="/images/graphics/smallbluesquare.png">
         System Status


### PR DESCRIPTION
For tablets and phones (i.e. mobile devices) if a web browser tab is not in focus the JavaScript that was running there is throttled or paused entirely.  For the eosstracker pages, this causes issues as execution of JavaScript to auto-update parts of the screen/map/etc are expecting to be able to run forever (so to speak) as if on a desktop computer.  On a mobile/tablet device, however, when a user returns to a browser tab that has been inactive for some time (i.e. the device has paused/throttled the JS running there), the web page can appear to be “stunned” and unresponsive.  Ultimately the user must close the tab and reopen the web page in a new browser tab.

In an attempt to address this, the “webfocus” branch will pause JavaScript execution when a browser tab loses focus on a mobile device and restarted when the user returns.