### PR TITLE
Pause javascript for those web pages that lose focus on mobile devices

### DIFF
--- a/www/common/map.js
+++ b/www/common/map.js
@@ -3425,7 +3425,6 @@ function gainFocus() {
 
     // if we're regaining focus, then restart periodic page updates.
     if (updateTimeout) {
-        var priorTimeout = updateTimeout;
         clearTimeout(updateTimeout);
         updateTimeout = setTimeout(updateAllItems, 5000);
     }


### PR DESCRIPTION
For tablets and phones (i.e. mobile devices) if a web browser tab is not in focus the JavaScript that was running there is throttled or paused entirely. For the eosstracker pages, this causes issues as execution of JavaScript to auto-update parts of the screen/map/etc are expecting to be able to run forever (so to speak) as if on a desktop computer. On a mobile/tablet device, however, when a user returns to a browser tab that has been inactive for some time (i.e. the device has paused/throttled the JS running there), the web page can appear to be “stunned” and unresponsive. Ultimately the user must close the tab and reopen the web page in a new browser tab.

In an attempt to address this, the “webfocus” branch will pause JavaScript execution when a browser tab loses focus on a mobile device and restarted when the user returns.