### PR TITLE
Updates to predict file downloads for new flights that are not active.

### DIFF
--- a/www/common/setup.js
+++ b/www/common/setup.js
@@ -784,11 +784,40 @@
         });
     }
 
+    /***********
+    * deletePredictFiles function
+    *
+    * This function will delete all predict files that are older than two weeks.
+    ***********/
+    function deletePredictFiles() {
+        var retVal = confirm("This will delete all prediction data older than two weeks.   Are you sure you want to delete this data?");
+        if (retVal == true)
+            $.get("deleteoldpredicts.php", function(data) {
+                var html;
+                var datetime = new Date();
+                var r;
+
+                html = "<p class=\"normal-italic\">Last attempt: " + datetime.toLocaleString() + "</p>";
+                for(r in data) {
+                    if (data[r].result != 0) 
+                        html = html + "<p class=\"normal-italic\"><mark class=\"notokay\">An error occured:  " + data[r].error + "</mark></p>";
+                    else
+                        html = html + "<p class=\"normal-italic\"><mark class=\"okay\">Success</mark></p>";
+                }
+
+                document.getElementById("deletepredictions-status").innerHTML = html;
+                setTimeout(function() {
+                    document.getElementById("deletepredictions-status").innerHTML = "";
+                }, 10000);
+                getPredictions();
+            });
+    }
+
 
     /***********
     * deletePrediction function
     *
-    * This function will delete the specified flight.
+    * This function will delete the specified flight predict file.
     ***********/
     function deletePrediction(flightid, thedate, launchsite) {
         var retVal = confirm("This will delete prediction data for " + flightid + " from " + thedate + " at the " + launchsite + " launch site.   Are you sure you want to delete this data?");

--- a/www/deleteoldpredicts.php
+++ b/www/deleteoldpredicts.php
@@ -1,0 +1,51 @@
+<?php
+/*
+*
+##################################################
+#    This file is part of the HABTracker project for tracking high altitude balloons.
+#
+#    Copyright (C) 2019,2020,2021 Jeff Deaton (N6BA)
+#
+#    HABTracker is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    HABTracker is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with HABTracker.  If not, see <https://www.gnu.org/licenses/>.
+#
+##################################################
+*
+ */
+
+
+session_start();
+if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
+    $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
+else
+    $documentroot = $_SERVER["DOCUMENT_ROOT"];
+include_once $documentroot . '/common/functions.php';
+header("Content-Type:  application/json;");
+
+    $link = connect_to_database();
+    if (!$link) {
+        db_error(sql_last_error());
+        return 0;
+    }
+
+    $query = "delete from predictiondata where thedate < now() - interval '14 day';";
+    $result = pg_query($link, $query);
+    if (!$result) {
+        printf("[{\"result\": \"1\", \"error\": \"A database error occurred.\"}]");
+        sql_close($link);
+        return 0;
+    }
+    printf("[{\"result\": \"0\", \"error\": \"Success\"}]");
+    sql_close($link);
+
+?>

--- a/www/grabprediction.php
+++ b/www/grabprediction.php
@@ -238,7 +238,8 @@ function getPredictFile($dbconn, $fid, $lsite, $url) {
     }
 
     // Get the list of active flights
-    $query = "select distinct flightid, launchsite from flights where active = 'y'";
+    //$query = "select distinct flightid, launchsite from flights where active = 'y'";
+    $query = "select distinct flightid, launchsite from flights where thedate > now() - interval '14 day' or active = 'y' order by flightid;";
     $result = pg_query($link, $query);
 
     // If this failed, then we have to exit.

--- a/www/setup.php
+++ b/www/setup.php
@@ -339,8 +339,8 @@ include $documentroot . '/common/header.php';
             </p>
             <p class="normal-italic" style="margin-top: 10px;">
                 Clicking the "Download Predict Files..." button will attempt to download the RAW predict files from 
-                <a class="normal-link-black" href="https://www.eoss.org/predict">https://www.eoss.org/predict</a> automatically for each flight the system 
-                is actively tracking.  This requires an Internet connection.
+                <a class="normal-link-black" href="https://www.eoss.org/predict">https://www.eoss.org/predict</a> for each flight that was recently added (< 2 weeks) 
+                to the system.  This requires an Internet connection.
             </p>
             <p class="subheader">
                 Add a Prediction Manually
@@ -365,6 +365,21 @@ include $documentroot . '/common/header.php';
             </p>
             <p >
                 <span id="predictiondata"></span>
+            </p>
+            <p>
+                <form name="deletepredictions" id="deletepredictions">
+                    <table cellpadding=0 cellspacing=0 border=0 style="margin-top: 10px;">
+                    <tr><td>
+                        <input class="submitbutton" style="margin: 5px; margin-left: 30px;" type="submit" value="Delete Old Predict Files" form="deletepredictions" onclick="deletePredictFiles(); return false;">
+                    </td>
+                    <td>
+                        <span style="margin: 5px; text-align: left;" id="deletepredictions-status"></span>
+                    </td>
+                    </table>
+                </form>  
+            </p> 
+            <p class="normal-italic" style="margin-top: 10px;">
+                Clicking the "Delete Old Predict Files" button will delete all predict files that are older than two weeks.
             </p>
             </div>
 


### PR DESCRIPTION
Download predict files for flights that were added < 14 days in addition to those that are active.  There are situations where a user might sync up with track.eoss.org which will bring down multiple flights.  However, some of those flights will not be active and therefore will not then have predict files auto-downloaded for them.  This change causes predict files to be downloaded for flights that were recently added (< 14 days) to the system in addition to active flights.

This also adds a new button on the Setup page under “Existing Predictions”  that will delete predict files that are older than two weeks.  This allows users to purge out older predict files that are of no use.