### PR TITLE
Early Cutdown Landing Predictions

### DIFF
--- a/bin/infocmd.py
+++ b/bin/infocmd.py
@@ -823,7 +823,7 @@ class infoCmd(object):
             debugmsg("============ infocmd landing_coords processing: %s : %s ==========" % (fid, callsign))
 
             try: 
-                # Get the latest landing prediction for the flight/beacon.  Only look back 20mins.
+                # Get the latest landing prediction for the flight/beacon.  Only look back 20mins and we exclude early cutdown predictions.
                 lastlandingprediction_sql = """
                     select 
                         l.tm as thetime,
@@ -839,6 +839,7 @@ class infoCmd(object):
                         and l.callsign = %s
                         and l.tm > (now() - interval '00:20:00')
                         and l.tm > now()::date
+                        and l.thetype in ('predicted', 'wind_adjusted', 'translated')
 
                     order by
                         l.tm desc 

--- a/www/common/map.js
+++ b/www/common/map.js
@@ -871,6 +871,30 @@
     }
 
     /*********
+    * this function is for styling the landing prediction paths/tracks for the pre-cutdown predictions
+    **********/
+
+    function landingPredictionStyleCutdown (feature) {
+        var localstyle;
+        var id = feature.properties.id;
+
+        if (feature.properties) {
+
+            // what sort of object is this?  
+            if ( ! feature.properties.objecttype)
+                return {};
+
+            var objecttype = feature.properties.objecttype;                    
+            if (objecttype == "landingpredictionpath") 
+                localstyle = { dashArray: "2 4", weight: 1, color : 'magenta', pane: 'pathsPane' };
+            else if (objecttype == "landingpredictionflightpath") 
+                localstyle = { dashArray: "3 6", weight: 2, color : 'red', pane: 'pathsPane' };
+            else
+                localstyle = {};
+        }
+        return localstyle;
+    }
+    /*********
     * this function is for styling the landing prediction paths/tracks 
     **********/
 
@@ -901,7 +925,7 @@
     *
     * This function is for creating a new realtime layer object.
     *********/
-    function createLandingPredictionsLayer(url, container, interval, fid) {
+    function createLandingPredictionsLayer(url, container, interval, fid, styleFunction) {
         return L.realtime(url, {
             interval: interval,
             container: container,
@@ -911,7 +935,7 @@
             weight: 2,
             opacity: 0.7,
             name: fid,
-            style:  landingPredictionStyle,
+            style:  (typeof(styleFunction) == "undefined" ? landingPredictionStyle : styleFunction),
             onEachFeature: function (feature, layer) {
                 var html = "";
                 var objecttype = feature.properties.objecttype;
@@ -1976,7 +2000,8 @@ function getTrackers() {
             /* prediction layer for early cutdown */
             var g = createLandingPredictionsLayer("", cutdownpredictionlayer, 
                 5 * 1000,
-                flightids[key].flightid
+                flightids[key].flightid,
+                landingPredictionStyleCutdown
             );
             d.addTo(map);
             f.addTo(map);

--- a/www/common/map.js
+++ b/www/common/map.js
@@ -1939,6 +1939,7 @@ function getTrackers() {
         for (key in flightids) {
             var predictedpathlayer = L.layerGroup();
             var landingpredictionlayer = L.layerGroup();
+            var cutdownpredictionlayer = L.layerGroup();
             var trackerstationslayer = L.layerGroup();
             var beacons = [];
 
@@ -1946,7 +1947,6 @@ function getTrackers() {
                 var activeflightlayer = L.featureGroup();
 
                 /* The active flight layer */
-                //var r = createActiveFlightsLayer("getactiveflights.php?flightid=" + flightids[key].flightid + "&callsign=" + flightids[key].callsigns[key2],
                 var r = createActiveFlightsLayer("",
                     activeflightlayer, 
                     5 * 1000, 
@@ -1964,30 +1964,36 @@ function getTrackers() {
             }
 
             /* The Trackers and Predict File layers */
-            //var d = createRealtimeLayer("gettrackerstations.php?flightid=" + flightids[key].flightid, true, trackerstationslayer, 5 * 1000, function(){ return { color: 'black'}});
-            //var e = createFlightPredictionLayer("getpredictionpaths.php?flightid=" + flightids[key].flightid, predictedpathlayer, 5 * 1000);
             var d = createRealtimeLayer("", false, trackerstationslayer, 5 * 1000, function(){ return { color: 'black'}});
             var e = createFlightPredictionLayer("", predictedpathlayer, 5 * 1000);
 
             /* The landing prediction layer */
-            //var f = createLandingPredictionsLayer("getlandingpredictions.php?flightid=" + flightids[key].flightid, landingpredictionlayer, 
             var f = createLandingPredictionsLayer("", landingpredictionlayer, 
+                5 * 1000,
+                flightids[key].flightid
+            );
+
+            /* prediction layer for early cutdown */
+            var g = createLandingPredictionsLayer("", cutdownpredictionlayer, 
                 5 * 1000,
                 flightids[key].flightid
             );
             d.addTo(map);
             f.addTo(map);
+            g.addTo(map);
 
             /* Add these layers to the map's layer control */
             layerControl.addOverlay(trackerstationslayer, "Trackers", "Flight:  " + flightids[key].flightid);
             layerControl.addOverlay(predictedpathlayer, "Pre-Flight Predicted Path", "Flight:  " + flightids[key].flightid);
             layerControl.addOverlay(landingpredictionlayer, "Landing Predictions", "Flight:  " + flightids[key].flightid);
+            layerControl.addOverlay(cutdownpredictionlayer, "Cutdown Predictions", "Flight:  " + flightids[key].flightid);
 
             flightList.push({
                 "flightid": flightids[key].flightid,
                 "trackerlayer": d,
                 "predictlayer": e,
                 "landinglayer": f,
+                "cutdownlayer": g,
                 "lastupdate": Date.now() / 1000,
                 "beacons": beacons
             });
@@ -2653,6 +2659,7 @@ function getTrackers() {
                     // The incoming JSON elements
                     var fid = x.flightid;
                     var landingJSON = x.landing;
+                    var cutdownJSON = x.cutdownlanding;
                     var predictJSON = x.predict;
                     var trackersJSON = x.trackers;
                     var packetlist = x.packetlist;
@@ -2710,6 +2717,45 @@ function getTrackers() {
                             }
                             else
                                 clearRealtimeLayer(flight.landinglayer);
+
+
+                            // Early Cutdown Landing predictions...
+                            if (cutdownJSON.features.length > 0) {
+                                var x;
+                                var f = flight.cutdownlayer;
+                                var group = f.options.container;
+
+                                // Loop through each feature within the existing landing layer looking for the breadcrumbs
+                                group.eachLayer(function(l) {
+                                    var id = l.feature.properties.id;
+
+                                    // is this a breadcrumb?
+                                    if (l.feature.properties.id.indexOf("_cutdownpredictionpoint_") !== -1) {
+                                        var y; 
+                                        var incoming = landingJSON.features;
+
+                                        // determine if this breadcrumb also appears within the incoming JSON
+                                        var foundit = false;
+                                        for (y in incoming) {
+                                            if (incoming[y].properties.id == id) {
+                                                foundit = true;
+                                                break;
+                                            }
+                                        }
+
+                                        // if the existing breadcrumb is not within the incoming JSON, then remove it from the map
+                                        if (!foundit && f.getFeature(id)) {
+                                            f.remove({"features": [{"properties": {"id": id}}]});
+                                        }
+                                    }
+                                });
+
+                                // Now add in all the incoming JSON
+                                flight.cutdownlayer.update(cutdownJSON);
+                            }
+                            else
+                                clearRealtimeLayer(flight.cutdownlayer);
+
 
                             // The pre-flight predict file...
                             if (predictJSON.features.length > 0) {

--- a/www/getflightdata.php
+++ b/www/getflightdata.php
@@ -1178,18 +1178,9 @@
     $cutdownlandings = [];
     $cutdownlandingfeatures = [];
 
-    # If this flights last couple of packets show a positive vertical rate, then we assume the flight is still assending.  In that case, we
-    # want to return data for an early cutdown prediction (assuming the backend has calculated one...obviously).  Otherwise, if the vertical rate
-    # for the flight is is < 0, then the flight is descending and we don't care about any sort of early cutdown landing predictions.
-    
-    $latest_vrate = 0;
-    if (sizeof($lastfewpackets) > 1)
-        # Just average the vertical rate from the last two packets  
-        $latest_vrate = ($lastfewpackets[0]["verticalrate"] + $lastfewpackets[1]["verticalrate"]) / 2.0;
-
-    # If the last packet from the flight is older than the lookback period, then we just return - we don't want to display landing predictions for older stuff.
-    # In addition, if the last packet from the flight is showing a negative vertical rate, then we skip this as the flight is already descending.
-    if ($seconds_since_last_packet < $config["lookbackperiod"] * 60 && $latest_vrate > 0) {
+    # If the last packet from the flight is older than the lookback period, then we just return.  
+    # We don't want to display landing predictions for older stuff.
+    if ($seconds_since_last_packet < $config["lookbackperiod"] * 60) {
 
         ## get the landing predictions...
         $query = "select 
@@ -1212,7 +1203,7 @@
             where 
             f.flightid = l.flightid 
             and f.active = 't' 
-            and l.thetype in ('cutdown')
+            and l.thetype in ('premature')
             and l.flightid = $1 
             and l.tm > (now() - (to_char(($2)::interval, 'HH24:MI:SS'))::time)  
 
@@ -1272,7 +1263,7 @@
                     "altitude" => "",
                     "time" => $timevalue,
                     "objecttype" => "landingprediction",
-                    "label" => $callsign . " Landing<br>(early cutdown)",
+                    "label" => $callsign . " Landing (early cutdown)",
                     "iconsize" => $config["iconsize"],
                     "ttl" => $ttl[$callsign]),
                 "geometry" => array(

--- a/www/getflightdata.php
+++ b/www/getflightdata.php
@@ -992,6 +992,7 @@
             where 
             f.flightid = l.flightid 
             and f.active = 't' 
+            and l.thetype in ('predicted', 'wind_adjusted', 'translated')
             and l.flightid = $1 
             and l.tm > (now() - (to_char(($2)::interval, 'HH24:MI:SS'))::time)  
 
@@ -1043,6 +1044,7 @@
             // Timestamp of the latest landing prediction record
             $timevalue = end($ray)[3];
 
+            // This is the point for the landing prediction itself
             $landingfeatures[] = array(
                 "type" => "Feature",
                 "properties" => array(
@@ -1065,7 +1067,6 @@
             );
 
 
-            // This is the point for the landing prediction itself
             // This is the linestring for the path the landing prediction point has taken as the landing prediction coords have changed.
             // We only want to plot the historical track the landing prediction has taken for "predicted" or "wind_adjusted" prediction types.  
             if (count($ray) > 1 && ($thetype[$callsign] == "predicted" || $thetype[$callsign] == "wind_adjusted")) {
@@ -1171,6 +1172,186 @@
         "features" => $landingfeatures
     );
 
+
+    /*=================== get cutdown/early-burst landing predictions for this flight ============ */
+
+    $cutdownlandings = [];
+    $cutdownlandingfeatures = [];
+
+    # If the last packet from the flight is older than the lookback period, then we just return.  
+    # We don't want to display landing predictions for older stuff.
+    if ($seconds_since_last_packet < $config["lookbackperiod"] * 60) {
+
+        ## get the landing predictions...
+        $query = "select 
+            date_trunc('millisecond', l.tm)::timestamp without time zone as thetime,
+            l.flightid, 
+            l.callsign, 
+            l.thetype, 
+            ST_Y(l.location2d) as lat, 
+            ST_X(l.location2d) as long,
+            ST_AsGeoJSON(l.flightpath) as flightpath,
+            --ST_astext(l.flightpath) as flightpath,
+            l.ttl,
+            array_to_json(l.patharray) as thepath,
+            array_to_json(l.winds) as thewind
+
+            from 
+            landingpredictions l, 
+            flights f 
+
+            where 
+            f.flightid = l.flightid 
+            and f.active = 't' 
+            and l.thetype in ('premature')
+            and l.flightid = $1 
+            and l.tm > (now() - (to_char(($2)::interval, 'HH24:MI:SS'))::time)  
+
+            order by 
+            l.tm asc, 
+            l.flightid, 
+            l.callsign;";
+
+        $result = pg_query_params($link, $query, array(
+            sql_escape_string($get_flightid),
+            sql_escape_string($config["lookbackperiod"] . " minute")
+        ));
+
+        if (!$result) {
+            db_error(sql_last_error());
+            sql_close($link);
+            return 0;
+        }
+        $features = array();
+        $flightpath = array();
+        $thepath = array();
+        while ($row = sql_fetch_array($result)) {
+            $thetime = $row['thetime'];
+            $callsign = $row['callsign'];
+            $thepath[$callsign] = json_decode($row['thepath']);
+            $thewind[$callsign] = json_decode($row['thewind']);
+            $flightid = $row['flightid'];
+            $thetype[$callsign] = $row['thetype'];
+            $latitude = $row['lat'];
+            $longitude = $row['long'];
+            $flightpath[$callsign] = json_decode($row['flightpath']);
+            $ttl[$callsign] = $row['ttl'];
+            $features[$callsign][$thetime. $latitude . $longitude] = array($latitude, $longitude, $row['thetype'], $thetime);
+        }
+
+
+        $numrows = sql_num_rows($result);
+
+
+        $firsttimeinloop = 1;
+        foreach ($features as $callsign => $ray) {
+            $firsttimeinloop = 0;
+
+            // Timestamp of the latest landing prediction record
+            $timevalue = end($ray)[3];
+
+            // This is the point for the landing prediction itself
+            $cutdownlandingfeatures[] = array(
+                "type" => "Feature",
+                "properties" => array(
+                    "id" => $callsign . "_cutdownlanding",
+                    "callsign" => $callsign . " Cutdown Predicted Landing",
+                    "tooltip" => $callsign . " Cutdown Landing",
+                    "symbol" => "/J",
+                    "comment" => "Landing prediction (early cutdown)",
+                    "frequency" => "",
+                    "altitude" => "",
+                    "time" => $timevalue,
+                    "objecttype" => "landingprediction",
+                    "label" => $callsign . " Landing (early cutdown)",
+                    "iconsize" => $config["iconsize"],
+                    "ttl" => $ttl[$callsign]),
+                "geometry" => array(
+                    "type" => "Point",
+                    "coordinates" => array(end($features[$callsign])[1], end($features[$callsign])[0])
+                )
+            );
+
+            // This is the linestring for the predicted flight path
+            // This is the flight path from the last location of the flight to the predicted landing spot (the "X" marks the spot).
+            if (array_key_exists($callsign, $flightpath)) {
+                if ($flightpath[$callsign]) {
+                    if (array_key_exists("coordinates", $flightpath[$callsign])) {
+                        $cutdownlandingfeatures[] = array(
+                            "type" => "Feature",
+                            "properties" => array(
+                                "id" => $callsign . "_cutdownflightpath_landing",
+                                "objecttype" => "landingpredictionflightpath",
+                                "time" => $timevalue
+                            ),
+                            "geometry" => $flightpath[$callsign]
+                        );
+                    }
+                }
+            }
+
+            // These are the breadcrumbs
+            if (array_key_exists($callsign, $thepath)) {
+                $i = 0;
+                $outerfirsttime = 1;
+                $firsttime = 1;
+                if (!empty($thepath[$callsign])) {
+                    $len = sizeof($thepath[$callsign]);
+
+                    // Get the first and last element of the $thepath array
+                    $first_tuple = reset($thepath[$callsign]);
+                    $last_tuple = end($thepath[$callsign]);
+
+                    // Now compute the span in altitude from the first element to the last
+                    $altitude_span = $first_tuple[3] - $last_tuple[3];
+
+                    // Now create a mod value for use below based on how large the altitude_span was.  
+                    // Bascially when:
+                    //     -  the altitude span is ~100k feet, then the mod should be about 20.
+                    //     -  the altitude span is ~4k feet, then the mod should be about 2.
+                    $mod_value = floor((16 * $altitude_span / 100000.0) + 2);
+
+                    $breadcrumb_num = 0;
+                    foreach ($thepath[$callsign] as $idx => $tuple) {
+
+                        if ($i < $len - 1 && $i > 0 && $i % $mod_value == 0) {
+                            //This is the GeoJSON object for the breadcrumb within the predicted flight path 
+
+
+                            $cutdownlandingfeatures[] = array(
+                                "type" => "Feature",
+                                "properties" => array(
+                                    "id" => $callsign . "_cutdownpredictionpoint_" . $breadcrumb_num,
+                                    "callsign" => $callsign,
+                                    "symbol" => "/J",
+                                    "altitude" => $tuple[3],
+                                    "time" => $timevalue,
+                                    "comment" => "Flight prediction (early cutdown)",
+                                    "objecttype" => "balloonmarker",
+                                    "tooltip" => round(floatval($tuple[3]) / 1000.0) . "k ft", 
+                                    "label" => round(floatval($tuple[3]) / 1000.0) . "k ft", 
+                                    "iconsize" => $config["iconsize"]
+                                ),
+                                "geometry" => array(
+                                    "type" => "Point",
+                                    "coordinates" => array($tuple[1], $tuple[0])
+                                )
+                            );
+
+                            $breadcrumb_num += 1;
+                        }
+                        $i += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    $cutdownlandings = array(
+        "type" => "FeatureCollection", 
+        "properties" => array("name" => "Predicted Landings (early cutdown)"),
+        "features" => $cutdownlandingfeatures
+    );
 
 
     /*=================== get pre-flight prediction (i.e. the "predict file") for this flight ============ */
@@ -1760,6 +1941,7 @@
     $outputJSON["trackers"] = $trackers;
     $outputJSON["beacons"] = $beacons;
     $outputJSON["landing"] = $landings;
+    $outputJSON["cutdownlanding"] = $cutdownlandings;
     $outputJSON["predict"] = $predicts;
     $outputJSON["packetlist"] = $packetlistJSON;
     $outputJSON["altitudechart"] = $altitudechart;

--- a/www/getflightdata.php
+++ b/www/getflightdata.php
@@ -388,7 +388,7 @@
         }
 
 
-        ## query the last packets from stations...
+        ## query the last packets from the flight...
         $query = "
             select
                 y.thetime,
@@ -1178,9 +1178,18 @@
     $cutdownlandings = [];
     $cutdownlandingfeatures = [];
 
-    # If the last packet from the flight is older than the lookback period, then we just return.  
-    # We don't want to display landing predictions for older stuff.
-    if ($seconds_since_last_packet < $config["lookbackperiod"] * 60) {
+    # If this flights last couple of packets show a positive vertical rate, then we assume the flight is still assending.  In that case, we
+    # want to return data for an early cutdown prediction (assuming the backend has calculated one...obviously).  Otherwise, if the vertical rate
+    # for the flight is is < 0, then the flight is descending and we don't care about any sort of early cutdown landing predictions.
+    
+    $latest_vrate = 0;
+    if (sizeof($lastfewpackets) > 1)
+        # Just average the vertical rate from the last two packets  
+        $latest_vrate = ($lastfewpackets[0]["verticalrate"] + $lastfewpackets[1]["verticalrate"]) / 2.0;
+
+    # If the last packet from the flight is older than the lookback period, then we just return - we don't want to display landing predictions for older stuff.
+    # In addition, if the last packet from the flight is showing a negative vertical rate, then we skip this as the flight is already descending.
+    if ($seconds_since_last_packet < $config["lookbackperiod"] * 60 && $latest_vrate > 0) {
 
         ## get the landing predictions...
         $query = "select 
@@ -1203,7 +1212,7 @@
             where 
             f.flightid = l.flightid 
             and f.active = 't' 
-            and l.thetype in ('premature')
+            and l.thetype in ('cutdown')
             and l.flightid = $1 
             and l.tm > (now() - (to_char(($2)::interval, 'HH24:MI:SS'))::time)  
 
@@ -1263,7 +1272,7 @@
                     "altitude" => "",
                     "time" => $timevalue,
                     "objecttype" => "landingprediction",
-                    "label" => $callsign . " Landing (early cutdown)",
+                    "label" => $callsign . " Landing<br>(early cutdown)",
                     "iconsize" => $config["iconsize"],
                     "ttl" => $ttl[$callsign]),
                 "geometry" => array(

--- a/www/getflightdata.php
+++ b/www/getflightdata.php
@@ -1266,7 +1266,7 @@
                     "id" => $callsign . "_cutdownlanding",
                     "callsign" => $callsign . " Cutdown Predicted Landing",
                     "tooltip" => $callsign . " Cutdown Landing",
-                    "symbol" => "/J",
+                    "symbol" => "/.",
                     "comment" => "Landing prediction (early cutdown)",
                     "frequency" => "",
                     "altitude" => "",


### PR DESCRIPTION
These changes add an additional layer to the map that displays an early cutdown landing prediction.  Early cutdown predictions are only calculated during a flight's ascent and show where a flight might land were it to suddenly start descending (ex. it was commanded to release the balloon, the balloon unexpectedly burst, etc.).  