### PR TITLE
Updates to allow for airspy SDR devices.

### DIFF
--- a/bin/aprsreceiver.py
+++ b/bin/aprsreceiver.py
@@ -1,7 +1,7 @@
 ##################################################
 #    This file is part of the HABTracker project for tracking high altitude balloons.
 #
-#    Copyright (C) 2019, 2020, Jeff Deaton (N6BA)
+#    Copyright (C) 2019, 2020, 2021 Jeff Deaton (N6BA)
 #
 #    HABTracker is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ from gnuradio import gr
 from gnuradio.eng_option import eng_option
 from gnuradio.filter import firdes
 import osmosdr
-
+import sys
 import signal
 
 
@@ -35,49 +35,95 @@ import signal
 #    This is the process that listens on various frequencies
 ##################################################
 class aprs_receiver(gr.top_block):
-    def __init__(self, freqlist=[(144390000, 12000)], rtl=0, prefix="rtl"):
+    def __init__(self, freqlist=[[144390000, 12000, "rtl", "n/a"]], rtl=0, prefix="rtl"):
         gr.top_block.__init__(self, "APRS Receiver for Multiple Frequencies")
 
-        ##################################################
-        # Parameters
-        ##################################################
+        # The frequency list
         self.Frequencies = freqlist
-        self.direwolf_audio_rate = 48000
+
+        # The RTL (or other device) prefix.  Used to tell the osmosdr source block which SDR device we want to use
         self.rtl_id = prefix + "=" + str(rtl)
 
-        ##################################################
-        # Variables
-        ##################################################
+        # MTU size for the size of packets we'll end up sending over UDP to direwolf
         self.mtusize = 9000
-        self.samp_rate = self.direwolf_audio_rate * 42
+
+        # Low pass filter parameters
         self.transition_width = 1000
         self.lowpass_freq = 5500
-        self.decimation = self.samp_rate / (self.direwolf_audio_rate)
-        self.scale = 14336
-        self.quadrate = self.samp_rate / self.decimation
-        self.max_deviation = 3300
-        self.lowpass_filter_0 = firdes.low_pass(20, self.samp_rate, self.lowpass_freq, self.transition_width, firdes.WIN_HANN, 6.76)
+
+        # NBFM demodulation params
+        #self.max_deviation = 3300
+        self.max_deviation = 5000
+
+        # Setting this scale to ~5000 as we'll use an AGC on the audio sent to direwolf.  Doing that means that Direwolf will report audio levels ~50 for most/all packets.
+        #self.scale = 14336
+        self.scale = 5119
+
+        # Center frequency
         self.center_freq = 145000000
 
-        ##################################################
-        # Blocks
-        ##################################################
-        self.osmosdr_source_0 = osmosdr.source( args="numchan=" + str(1) + " " + self.rtl_id )
-        self.osmosdr_source_0.set_sample_rate(self.samp_rate)
+        # This is the main source block that reads IQ data from the SDR
+        self.osmosdr_source_0 = osmosdr.source( args="numchan=" + str(1) + " " + self.rtl_id)
         self.osmosdr_source_0.set_center_freq(self.center_freq, 0)
         self.osmosdr_source_0.set_freq_corr(0, 0)
         self.osmosdr_source_0.set_dc_offset_mode(2, 0)
         self.osmosdr_source_0.set_iq_balance_mode(0, 0)
-        self.osmosdr_source_0.set_gain_mode(True, 0)
-        self.osmosdr_source_0.set_gain(40, 0)
-        self.osmosdr_source_0.set_if_gain(20, 0)
-        self.osmosdr_source_0.set_bb_gain(20, 0)
         self.osmosdr_source_0.set_antenna('', 0)
         self.osmosdr_source_0.set_bandwidth(0, 0)
 
-        for freq,port in self.Frequencies:
-            #print "   channel:  [%d] %dMHz" % (port, freq)
-            #print "   quadrate:  %d" % (self.quadrate)
+        # Airspy R2 / Mini can only accommodate specific sample rates and uses device specific RF gains, so we need to adjust values to accommodate
+        if prefix == "airspy":
+
+            # Setting the direwolf audio rate to be a multiple of the 2.5M, 3.0M, 6.0M, and 10.0M sample rates that the airspy devices can run.
+            self.direwolf_audio_rate = 50000
+
+            # Get the first valid sample rate for the airspy device.  This *should* be the lowest sample rate allowed by the device.
+            rates = self.osmosdr_source_0.get_sample_rates()
+            r = rates[0]
+            self.samp_rate = int(r.start())
+
+            # Turn off hardware AGC
+            self.osmosdr_source_0.set_gain_mode(False, 0)
+
+            # Set gains (specific to airspy devices).  These are the max values within libairspy and have been verified to produce the best SINAD results (@144.39MHz, @12dB)
+            self.osmosdr_source_0.set_gain(14, 'LNA', 0)
+            self.osmosdr_source_0.set_gain(12, 'MIX', 0)
+            self.osmosdr_source_0.set_gain(13,  'IF',  0)
+
+        # Not an airspy device...so we set sample rates and parameters as multiples of a 48k audio sample rate that direwolf will use
+        else:
+
+            # Setting the direwolf audio rate to be 48k (quasi standard for audio).
+            self.direwolf_audio_rate = 48000
+
+            # Set the sample rate as a multiple of the direwolf audio rate
+            self.samp_rate = self.direwolf_audio_rate * 42
+
+            # Turn on hardware AGC
+            self.osmosdr_source_0.set_gain_mode(True, 0)
+
+            # Set gains, just in case
+            self.osmosdr_source_0.set_gain(40, 0)
+            self.osmosdr_source_0.set_if_gain(20, 0)
+            self.osmosdr_source_0.set_bb_gain(20, 0)
+
+        # set the source block's sample rate now that we know that.
+        self.osmosdr_source_0.set_sample_rate(self.samp_rate)
+
+        # Decimation factor
+        self.decimation = self.samp_rate / (self.direwolf_audio_rate)
+
+        # Quadrature rate (input rate for the NBFM block)
+        self.quadrate = self.samp_rate / self.decimation
+
+        # Low pass filter taps
+        self.lowpass_filter_0 = firdes.low_pass(20, self.samp_rate, self.lowpass_freq, self.transition_width, firdes.WIN_HANN, 6.76)
+
+        # Now construct a seperate processing chain for each frequency we're listening to.
+        # processing chain:
+        #    osmosdr_source ---> xlating_fir_filter ---> nbfm ---> agc ---> float_to_short ---> UDP_sink
+        #
+        for freq,port,p,sn in self.Frequencies:
             freq_xlating_fir_filter = filter.freq_xlating_fir_filter_ccf(self.decimation, (self.lowpass_filter_0), freq-self.center_freq, self.samp_rate)
             blocks_udp_sink = blocks.udp_sink(gr.sizeof_short*1, '127.0.0.1', port, self.mtusize, True)
             blocks_float_to_short = blocks.float_to_short(1, self.scale)
@@ -88,20 +134,33 @@ class aprs_receiver(gr.top_block):
                 max_dev=self.max_deviation,
             )
 
+            # AGC to normalize the audio levels sent to Direwolf
+            analog_agc = analog.agc_ff(1e-5, 1.0, 1.0)
+            analog_agc.set_max_gain(65536)
+
             ##################################################
             # Connections
             ##################################################
-            self.connect((analog_nbfm_rx, 0), (blocks_float_to_short, 0))
-            self.connect((blocks_float_to_short, 0), (blocks_udp_sink, 0))
-            self.connect((freq_xlating_fir_filter, 0), (analog_nbfm_rx, 0))
             self.connect((self.osmosdr_source_0, 0), (freq_xlating_fir_filter, 0))
+            self.connect((freq_xlating_fir_filter, 0), (analog_nbfm_rx, 0))
+            self.connect((analog_nbfm_rx, 0), (analog_agc, 0))
+            self.connect((analog_agc, 0), (blocks_float_to_short, 0))
+            self.connect((blocks_float_to_short, 0), (blocks_udp_sink, 0))
+
+        # Query the osmosdr block to determine just what gain and sample rates it set for the airspy device
+        if prefix == "airspy":
+            print "Airspy LNA Gain set to:  ", self.osmosdr_source_0.get_gain("LNA")
+            print "Airspy MIX Gain set to:  ", self.osmosdr_source_0.get_gain("MIX")
+            print "Airspy VGA Gain set to:  ", self.osmosdr_source_0.get_gain("IF")
+            print "Airspy sample rate set to:  ", str(round(float(self.samp_rate) / 1000000.0, 3)) + "M"
+            sys.stdout.flush()
 
 
 ##################################################
 # GRProcess:
 #    - Then starts up an instance of the aprs_receiver class
 ##################################################
-def GRProcess(flist=[(144390000, 12000)], rtl=0, prefix="rtl", e = None):
+def GRProcess(flist=[[144390000, 12000, "rtl", "n/a"]], rtl=0, prefix="rtl", e = None):
     try:
 
         #print "GR [%d], listening on: " % rtl, flist

--- a/bin/searchrtlsdr.py
+++ b/bin/searchrtlsdr.py
@@ -1,7 +1,7 @@
 ##################################################
 #    This file is part of the HABTracker project for tracking high altitude balloons.
 #
-#    Copyright (C) 2019,2020 Jeff Deaton (N6BA)
+#    Copyright (C) 2019,2020,2021 Jeff Deaton (N6BA)
 #
 #    HABTracker is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -67,10 +67,14 @@ known_devices = [
     { "vendor": 0x1f4d, "product": 0xd286, "prefix":"rtl", "description": "MyGica TD312" },
     { "vendor": 0x1f4d, "product": 0xd803, "prefix":"rtl", "description": "PROlectrix DV107669" },
     { "vendor": 0x1d50, "product": 0x6089, "prefix": "hackrf", "description": "OpenMoko, Inc. Great Scott Gadgets HackRF One SDR" },
+    { "vendor": 0x1d50, "product": 0x60a1, "prefix": "airspy", "description": "Airspy" }
 ]
 
 def getUSBDevices():
-    i = 0
+
+    # Probably need to fix this to be more dynamic...
+    device_no = { "rtl": 0, "hackrf" : 0, "airspy" : 0}
+
     sdrs = []
 
     # Get a list of usb devices
@@ -103,7 +107,7 @@ def getUSBDevices():
                 m = m if m else ""
 
                 # Create a dict for this device
-                rtl = { "rtl" : i, "manufacturer" : m, "product" : p, "serialnumber" : s, "description" : sdr["description"], "prefix" : sdr["prefix"]}
+                rtl = { "rtl" : device_no[sdr["prefix"]], "manufacturer" : m, "product" : p, "serialnumber" : s, "description" : sdr["description"], "prefix" : sdr["prefix"]}
 
                 # Check if the RTLSDR is using a serial number string that contains "adsb".
                 #     The idea being, not to use any SDR attached that is to be used for ADS-B reception instead.
@@ -112,6 +116,6 @@ def getUSBDevices():
                 else:
                     sdrs.append(rtl)
 
-                i = i+1
+                device_no[sdr["prefix"]] += 1
         return sdrs
 


### PR DESCRIPTION
This should autodetect the lowest, valid sample rate of the airspy SDR device and use that to build the gnuradio processing chain.  Gain values for airspy devices are set to appropriate values - Airspy devices use different RF gain values and require setting those manually (as apposed to the standard interfaces for a regular RTL-SDR).  

Updates to comment lines auto-inserted into the direwolf.conf file to denote which ADEVICE corresponds to which SDR device.  This should make it more clear for those use cases where multiple SDR devices are in play.  The creation of the direwolf.conf file will now check if 145.825MHz is being listened to and adjust the direwolf igating filters to block igating of APRS packets there were heard directly over that frequency.  When using for satellite ops one only wants to igate digipeated packets (i.e. those bounced off of the ISS, PSAT, etc.).