### PR TITLE
Update so that the last 50 lines of the direwolf.out log file are continuously displayed on the home web page

### DIFF
--- a/www/getlogs.php
+++ b/www/getlogs.php
@@ -52,7 +52,7 @@
     $beacons = [];
     $matches = [];
     if (is_readable($direwolffile)) {
-        $dw = shell_exec('head -100 ' . $direwolffile);
+        $dw = shell_exec('tail -50 ' . $direwolffile);
         $dw_beacons = shell_exec("awk '/(^\[ig\] [A-Z]{1,2}[0-9]{1}[A-Z]{1,3})|(\[[0-9]+L [0-9]{1,2}\/[0-9]{1,2}\/[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2}\] [A-Z]{1,2}[0-9]{1}[A-Z]{1,3})/' " . $direwolffile);
         $p = preg_match_all('/^(\[[0-9]+L [0-9]{1,2}\/[0-9]{1,2}\/[0-9]{1,2} [0-9]{1,2}:[0-9]{2}:[0-9]{2}\]|\[ig\]) .*$/m', $dw_beacons, $matches);
    	    if ($p) {

--- a/www/index.php
+++ b/www/index.php
@@ -152,7 +152,7 @@ include $documentroot . '/common/header.php';
     <pre class="packetdata" ><span id="errfile"></span></pre>
     <p class="packetdata-header">Transmitted Beacons (last 10 transmissions)</p>
     <pre class="packetdata" ><span id="beacons"></span></pre>
-    <p class="packetdata-header">Direwolf output (limited to the first 100 lines)</p>
+    <p class="packetdata-header">Direwolf Output</p>
     <pre class="packetdata" ><span id="direwolf"></span></pre>
     <p><span id="debug"></span></p>
 </div>


### PR DESCRIPTION
Changing the underlying command to be, "tail -50", instead of "head -100".  That way updates to the direwolf log file are continuously updated (on the web page) and users can watch the output of the direwolf log file for troubleshooting purposes.