### PR TITLE
Skip over position packets from beacons that might have bad GPS, Time, or Altitude data in the landing predictor.

### DIFF
--- a/bin/landingpredictor.py
+++ b/bin/landingpredictor.py
@@ -1455,7 +1455,8 @@ class LandingPredictor(PredictorBase):
                                     --floor(extract(epoch from a.tm) / 30) * 30
 
                                     order by 
-                                    a.tm asc
+                                    a.tm asc,
+                                    a.channel desc
                                 )
 
                                 from 
@@ -1478,6 +1479,7 @@ class LandingPredictor(PredictorBase):
                         
                         where 
                         c.dense_rank = 1
+                        and abs(extract('epoch' from (c.thetime::time - c.packet_time::time))) < 120
 
                     ) as y
                     left outer join
@@ -1519,6 +1521,11 @@ class LandingPredictor(PredictorBase):
                         r.tm
                     ) as lp
                     on lp.flightid = y.flightid and lp.callsign = y.callsign
+                    
+                where
+                    abs(y.lat - y.previous_lat) < 1 
+                    and abs(y.lon - y.previous_lon) < 1 
+                    and abs(y.altitude - y.previous_altitude) < 10000
 
                 order by
                     y.callsign,


### PR DESCRIPTION
This updates the SQL statement responsible for getting a list of position packets for a given beacon as part of the landing prediction process.  In addition, to skipping over those packets that have a bad timestamp (> 120secs vs. the receive time), bad GPS coords(> 1degree difference vs. prior position), or bad altitude values (> 10000 feet difference vs. prior altitude), this also ensures that there is only one packet returned (ex. Those cases where multiple packets are added to the databases from different sources like additional SDR’s or APRS-IS).