### PR TITLE
Change packet quality checks from absolute value to rate-based

### DIFF
--- a/bin/queries.py
+++ b/bin/queries.py
@@ -321,9 +321,21 @@ def getLatestPackets(dbconn, callsign = None, timezone = None, timecutoff_mins =
                 ) as y
                 
             where
-                abs(y.lat - y.previous_lat) < 1 
-                and abs(y.lon - y.previous_lon) < 1 
-                and abs(y.altitude - y.previous_altitude) < 10000
+                case when y.delta_secs > 0 then
+                    abs((y.altitude - y.previous_altitude) / y.delta_secs)
+                else
+                    0
+                end < 1000
+                and case when y.delta_secs > 0 then
+                    abs((y.lat - y.previous_lat) / y.delta_secs)
+                else
+                    0
+                end < .04
+                and case when y.delta_secs > 0 then
+                    abs((y.lon - y.previous_lon) / y.delta_secs)
+                else
+                    0
+                end < .04
 
             order by
                 y.callsign,


### PR DESCRIPTION
Using the latitude, longitude, and altitude change rates from one packet to the next is a better way to filter out those packets that have bogus values for position.  This change seeks to filter out those packets that would have an object moving at > ~255mph (ex. > 0.04 degrees/sec of lat/lon) or an altitude change rate of > 1000ft/s.  