### PR TITLE
Further corrections to the time values for TTL on the map.

### DIFF
--- a/www/getflightdata.php
+++ b/www/getflightdata.php
@@ -597,7 +597,8 @@
                             landingpredictions l
 
                             where
-                            l.tm > now() - interval '00:10:00'
+                            --l.tm > now() - interval '00:10:00'
+                            l.tm > (now() - (to_char(($5)::interval, 'HH24:MI:SS'))::time)  
                             and l.ttl is not null
 
                             order by
@@ -627,7 +628,7 @@
                         gpsposition g 
 
                         where
-                        g.tm > (now() - (to_char(($5)::interval, 'HH24:MI:SS'))::time)
+                        g.tm > (now() - (to_char(($6)::interval, 'HH24:MI:SS'))::time)
 
                         order by 
                         g.tm desc
@@ -667,6 +668,7 @@
                 sql_escape_string($config["lookbackperiod"] . " minute"), 
                 $get_starttime,
                 sql_escape_string($cs),
+                sql_escape_string($config["lookbackperiod"] . " minute"), 
                 sql_escape_string($config["lookbackperiod"] . " minute"), 
                 )
             );

--- a/www/getflightdata.php
+++ b/www/getflightdata.php
@@ -597,8 +597,7 @@
                             landingpredictions l
 
                             where
-                            --l.tm > now() - interval '00:10:00'
-                            l.tm > (now() - (to_char(($5)::interval, 'HH24:MI:SS'))::time)  
+                            l.tm > now() - interval '00:20:00'
                             and l.ttl is not null
 
                             order by
@@ -628,7 +627,7 @@
                         gpsposition g 
 
                         where
-                        g.tm > (now() - (to_char(($6)::interval, 'HH24:MI:SS'))::time)
+                        g.tm > (now() - (to_char(($5)::interval, 'HH24:MI:SS'))::time)
 
                         order by 
                         g.tm desc
@@ -668,7 +667,6 @@
                 sql_escape_string($config["lookbackperiod"] . " minute"), 
                 $get_starttime,
                 sql_escape_string($cs),
-                sql_escape_string($config["lookbackperiod"] . " minute"), 
                 sql_escape_string($config["lookbackperiod"] . " minute"), 
                 )
             );

--- a/www/map.php
+++ b/www/map.php
@@ -385,7 +385,7 @@
         printf ("<div class=\"div-table\">");
         printf ("   <div class=\"table-row\">");
         printf ("       <div class=\"panel-cell\">");
-        printf ("           <div style=\"margin: 5px;\">Time to live: &nbsp; <span id=\"%s\">n/a mins</span></div>", $row['flightid'] . "_ttl");
+        printf ("           <div style=\"margin: 5px;\">Time to live: &nbsp; <span id=\"%s\">n/a</span></div>", $row['flightid'] . "_ttl");
         printf ("       </div>");
         printf ("   </div>");
         printf ("</div>");


### PR DESCRIPTION
The time values used for TTL within the sidebar on the map were not updating based on the latest landing prediction TTL values.  In addition, the SQL query used for gathering that TTL info was not using a look back period of 20mins which is the standard “cutoff” when querying landing prediction records.