### PR TITLE
APRS messages tab on the map sidebar and ability to select the prefix ARISS for transmissions

### DIFF
--- a/bin/direwolf.py
+++ b/bin/direwolf.py
@@ -125,7 +125,13 @@ def createDirewolfConfig(callsign, l, configdata, gpsposition):
                 # If this is a mobile station, then we want to turn on "smart" beaconing.
                 viapath = ""
                 if configdata["mobilestation"] == "true":
-                    viapath = " via=" + str(eoss) + "WIDE1-1,WIDE2-1"
+
+                    # If we're using AIRSS then we assuming the external radio is transmitting on 145.825MHz and we alter our path to only add WIDE2-1.
+                    if str(configdata["eoss_string"]) == "ARISS":
+                        viapath = " via=" + str(eoss) + "WIDE2-1"
+                    else:
+                        viapath = " via=" + str(eoss) + "WIDE1-1,WIDE2-1"
+
                     f.write("# This is for a mobile station\n")
                     f.write("TBEACON sendto=" + str(channel) + " delay=0:30 every=" + str(configdata["beaconlimit"]) + "  altitude=1 " + viapath + " symbol=" + str(configdata["symbol"]) + overlay + "    comment=\"" + str(configdata["comment"]) +  "\"\n")
                     f.write("SMARTBEACONING " + str(configdata["fastspeed"]) + " " + str(configdata["fastrate"]) + "      " + str(configdata["slowspeed"]) + " " + str(configdata["slowrate"]) + "     " + str(configdata["beaconlimit"]) + "     " + str(configdata["fastturn"]) + " " + str(configdata["slowturn"]) + "\n")

--- a/bin/habtracker-daemon.py
+++ b/bin/habtracker-daemon.py
@@ -376,6 +376,22 @@ def databaseUpdates():
                 dbcur.execute(sql_add)
                 dbconn.commit()
 
+
+        # SQL to add an index on the tm, source, and ptype columns of the packets table
+        sql_exists = "select exists (select * from pg_indexes where schemaname='public' and tablename = 'packets' and indexname = 'packets_tm_source_ptype');"
+        dbcur.execute(sql_exists)
+        rows = dbcur.fetchall()
+        if len(rows) > 0:
+            if rows[0][0] == False:
+                # Add the index since it didn't seem to exist.
+                sql_add = "create index packets_tm_source_ptype on packets(tm, source, ptype);"
+                print "Adding packets_tm_source_ptype index."
+                sys.stdout.flush()
+                debugmsg("Adding packets_tm_source_ptype index to the packets table: %s" % sql_add)
+                dbcur.execute(sql_add)
+                dbconn.commit()
+
+
         #------------------- packets table ------------------#
 
         ts = datetime.datetime.now()

--- a/www/common/map.js
+++ b/www/common/map.js
@@ -3160,7 +3160,7 @@ function getTrackers() {
                 // Was this to/from a satellite?
                 var sat = "";
                 if (m.sat * 1.0 == 1) 
-                    sat = "<p class=\"normal\" style=\"margin: 0; background-color: lightgreen;\">Satellite</p>";
+                    sat = "<br><mark class=\"okay\">[ Satellite ]</mark>";
 
                 // Search through the map layers to determine if the sender of this message is on the map
                 // First, look through the RF stations layer (as that's likely where the station is...so we search it first).

--- a/www/common/map.js
+++ b/www/common/map.js
@@ -3115,6 +3115,17 @@ function getTrackers() {
         else {
             msgs.forEach(function(m, i) {
 
+                // Make sure all of the JSON elements are defined
+                if (typeof(m.callsign_to) == "undefined" ||
+                    typeof(m.callsign_from) == "undefined" ||
+                    typeof(m.thetime) == "undefined" || 
+                    typeof(m.the_message) == "undefined" ||
+                    typeof(m.message_num) == "undefined" ||
+                    typeof(m.sat) == "undefined") {
+                    return;
+                }
+
+
                 // create a row for this message
                 row = table.insertRow(-1);
 

--- a/www/common/map.js
+++ b/www/common/map.js
@@ -3089,6 +3089,7 @@ function getTrackers() {
         // the table itself
         var table = document.createElement("table");
         table.setAttribute("class", "packetlist");
+        table.setAttribute("width", "100%");
 
         // the columns
         //var columns = ["Time", "To", "From", "Msg #"];

--- a/www/common/map.js
+++ b/www/common/map.js
@@ -69,6 +69,9 @@
     var livePacketStreamState = 0;;
     var processInTransition = 0;
 
+    // callsign 
+    var mycallsign;
+
     // The list of realtime layers 
     var realtimeflightlayers = [];
     var landingpredictionlayers = [];
@@ -1435,6 +1438,10 @@
 		    document.getElementById("lookbackperiod").value = jsonData.lookbackperiod;
             lookbackPeriod = jsonData.lookbackperiod * 1.0;
 
+            if (typeof(jsonData.callsign) != "undefined")
+                if (jsonData.callsign != "")
+                    mycallsign = jsonData.callsign.toUpperCase();
+
 		    /*if (jsonData.plottracks == "on")
 			    document.getElementById("plottracks").checked = true;
 		    else
@@ -1446,7 +1453,6 @@
 			    document.getElementById("airdensity").checked = false;
             });
     }
-
 
 
 
@@ -3057,7 +3063,139 @@ function getTrackers() {
                 }
             });
 
+            // APRS messages packets
+            if (typeof(data.messages) != "undefined") {
+                updateMessagesTable(data.messages);
+            }
+
         });
+    }
+
+
+
+    /************
+     * updateMessagesTable
+     *
+     * With a list of messages as input, create a table within the sidebar for these APRS message packets highlighting any that are addressed to mycallsign.
+     *
+     * Example:  [{"thetime":"2021-11-12T07:22:52.392","callsign_from":"SP9UOB-12","callsign_to":"EMAIL-2","the_message":"sp9uob@gmail.com tracker boot 2630 144390000 kHz last=50.33168,-125.64470 rtc=396","message_num":"2630"}]
+    *************/
+    function updateMessagesTable(msgs) {
+        var keys = Object.keys(msgs);
+
+        // the element that we'll ultimately load our content into
+        var container = document.getElementById("packetdata");
+
+        // the table itself
+        var table = document.createElement("table");
+        table.setAttribute("class", "packetlist");
+
+        // the columns
+        //var columns = ["Time", "To", "From", "Msg #"];
+        var columns = ["Time", "Message"];
+
+        // Add the header row
+        var row = table.insertRow(-1);
+        columns.forEach(function(l) {
+            var headerCell = row.insertCell(-1);
+            headerCell.innerHTML = l;
+            headerCell.setAttribute("class", "packetlistheader");
+        });
+
+        // Now add the messages themselves to the table
+        if (keys.length == 0) {
+            row = table.insertRow(-1);
+            var blankcell1 = row.insertCell(-1);
+            var blankcell2 = row.insertCell(-1);
+            blankcell1.setAttribute("class", "packetlist");
+            blankcell2.setAttribute("class", "packetlist");
+            blankcell1.innerHTML = "n/a";
+            blankcell2.innerHTML = "No messages available.";
+        }
+        else {
+            msgs.forEach(function(m, i) {
+
+                // create a row for this message
+                row = table.insertRow(-1);
+
+                // Cells for each data element
+                var time = row.insertCell(-1);
+                var content = row.insertCell(-1);
+
+                var classlist = "packetlist";
+
+                // change the background color on every other row
+                if (i % 2) {
+                    classlist = "packetlist highlight";
+                }
+
+                // If this message is addressed directly to "mycallsign", then change the highlighting
+                if (mycallsign == m.callsign_to.toUpperCase()) {
+                    classlist = "packetlist important";
+                }
+
+                time.setAttribute("class", classlist + " normal");
+                content.setAttribute("class", classlist + " monospace");
+
+                // create a new date object fromt the time
+                var thetime = new Date(m.thetime);
+
+                // create a 24hr time string
+                var time_string = (thetime.getHours() < 10 ? "0" : "") + thetime.getHours() + ":" 
+                    + (thetime.getMinutes() < 10 ? "0" : "") + thetime.getMinutes() + ":" 
+                    + (thetime.getSeconds() < 10 ? "0" : "") + thetime.getSeconds();
+
+                // Was this to/from a satellite?
+                var sat = "";
+                if (m.sat * 1.0 == 1) 
+                    sat = "<p class=\"normal\" style=\"margin: 0; background-color: lightgreen;\">Satellite</p>";
+
+                // Search through the map layers to determine if the sender of this message is on the map
+                // First, look through the RF stations layer (as that's likely where the station is...so we search it first).
+                var found = rfStationsLayer.getFeature(m.callsign_from.toUpperCase());
+
+                // if not found, then we next check the at large trackers layer
+                if (!found) 
+                    found = trackersAtLargeLayer.getFeature(m.callsign_from.toUpperCase());
+
+                // if still not found, then we next check the the trackers layers from each active flight
+                if (!found) {
+                    flightList.forEach(function(f) {
+                        var trackers = f.trackerlayer;
+                        var id = trackers.getFeature(m.callsign_from.toUpperCase());
+
+                        if (id)
+                            found = id;
+                    });
+                }
+
+                // If we found the sender's station on the map, then grab the lat/lon and create a hyperlink for panning the map.
+                var fromStation;
+                if (found && found.geometry.coordinates) {
+                    fromStation = "<a href=\"#\"  onclick=\"dispatchPanToEvent('" + found.geometry.coordinates[1] + "', '" + found.geometry.coordinates[0] + "');\">" +  m.callsign_from.toUpperCase() + "</a>"
+                }
+                else
+                    fromStation = m.callsign_from.toUpperCase();
+
+                var html = "<table cellpadding=0 cellspacing=0 border=0><tr><td><font class=\"normal\">From: </font></td><td>" + fromStation + "</td></tr>"
+                    + "<tr><td><font class=\"normal\">To: </font></td><td>" + m.callsign_to.toUpperCase() + "</td></tr>"
+                    + "<tr><td><font class=\"normal\">Msg#: </font></td><td>" + (m.message_num ? m.message_num : "--") + "</td></tr></table>"
+                    + "<p>" + m.the_message + "</p>";
+
+                // Update content of the cells
+                time.innerHTML = time_string + sat;
+                content.innerHTML = html;
+
+            });
+        }
+
+
+        // Blank the container to clear out any prior data
+        container.innerHTML = "";
+
+        // Now update with our content
+        container.appendChild(table);
+
     }
 
 

--- a/www/common/map.js
+++ b/www/common/map.js
@@ -3184,7 +3184,10 @@ function getTrackers() {
                 // If we found the sender's station on the map, then grab the lat/lon and create a hyperlink for panning the map.
                 var fromStation;
                 if (found && found.geometry.coordinates) {
-                    fromStation = "<a href=\"#\"  onclick=\"dispatchPanToEvent('" + found.geometry.coordinates[1] + "', '" + found.geometry.coordinates[0] + "');\">" +  m.callsign_from.toUpperCase() + "</a>"
+                    var onclick;
+
+                    onclick="(function () { if (!map.hasLayer(rfStationsLayer.options.container)) map.addLayer(rfStationsLayer.options.container); dispatchPanToEvent('" + found.geometry.coordinates[1] + "', '" + found.geometry.coordinates[0] + "'); })();";
+                    fromStation = "<a href=\"#\"  onclick=\"" + onclick + "\">" + m.callsign_from.toUpperCase() + "</a>";
                 }
                 else
                     fromStation = m.callsign_from.toUpperCase();

--- a/www/common/mapstyles.css
+++ b/www/common/mapstyles.css
@@ -366,7 +366,7 @@ td.packetlistright {
 
 .monospace {
     font-family:  "Lucida Console", Monaco, monospace;
-    font-size:  .85em;
+    font-size:  1em;
     text-align:  left;
     white-space: pre-wrap;
     word-wrap: break-word;

--- a/www/common/mapstyles.css
+++ b/www/common/mapstyles.css
@@ -246,14 +246,44 @@ div.table-cell.header {
     background-color: #0074d9;
     font-variant:  small-caps;
     color: white;
+    white-space: nowrap;
 }
 
 div.table-cell.important {
-    background-color: #996300;
+    background-color: yellow;
+}
+
+.important {
+    background-color: yellow;
+}
+
+.highlight {
+    background-color: #d9d9d9;
+}
+
+div.table-cell.highlight {
+    background-color: #d9d9d9;
 }
 
 div.table-cell.toprow {
     border-top: solid 1px black;
+}
+
+div.table-cell.nowrap {
+    white-space: nowrap;
+}
+
+div.table-cell.packetdata {
+    white-space: break-word;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    text-decoration: none;
+    font-family:  "Lucida Console", Monaco, monospace;
+    font-size:  .85em;
+    text-align:  left;
+    /*vertical-align: top;
+    background-color: #d3d3d3;*/
+    color: black; 
 }
 
 div.table-cell:first-child {
@@ -291,6 +321,20 @@ div.table-cell:last-child {
     font-size:  1.2em;
 }
 
+.dottedborderbottom {
+    border-left: 1px solid black;
+    border-right: 1px solid black;
+    border-top: 1px solid black;
+    border-bottom: 1px dashed black;
+}
+
+.dottedbordertop {
+    border-left: 1px solid black;
+    border-right: 1px solid black;
+    border-top: 1px dashed black;
+    border-bottom: 1px solid black;
+}
+
 .packetlist {
     text-align: left;
     white-space: nowrap;
@@ -302,7 +346,7 @@ div.table-cell:last-child {
     padding-right:  5px;
     padding-left:  5px;
     font-size:  1em;
-    width:  100%;
+    /*width:  100%;*/
 }
 
 td.packetlistright {
@@ -320,11 +364,20 @@ td.packetlistright {
 
 
 
+.monospace {
+    font-family:  "Lucida Console", Monaco, monospace;
+    font-size:  .85em;
+    text-align:  left;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
 
 .packetlistheader {
     color:  white;
     text-decoration:none;
-    white-space: normal;
+    white-space: nowrap;
     font-variant:  small-caps;
     border:  solid 1px black;
     background-color: #0074d9;
@@ -410,7 +463,7 @@ a.section-link:hover { text-decoration: underline; }
 }
 
 .normal {
-    color: #303030;
+    color: #303030; 
     font-family:  "Gill Sans", "GillSans", "Helvetica", "san-serif";
     font-size: 1em;
 }

--- a/www/getotherdata.php
+++ b/www/getotherdata.php
@@ -975,7 +975,11 @@
     printf (", \"messages\" : ");
     if ($numrows > 0) {
         $rows = sql_fetch_all($result);
-        printf("%s", $rows[0]['json']);
+        if ($rows[0]['json'] != "")
+            printf("%s", $rows[0]['json']);
+        else
+            printf("[]");
+
     }
     else 
         printf("[]");

--- a/www/map.php
+++ b/www/map.php
@@ -139,7 +139,7 @@
                 <!-- <li><a href="#screenh" role="tab"><span id="screenh"></span></a></li> -->
                 <li><a href="#home" role="tab"><img src="/images/graphics/home.png" width="30" height="30"></a></li>
                 <li><a href="#profile" role="tab"><img src="/images/graphics/profile.png" width="30" height="30"></a></li>
-                <!-- <li><a href="#messages" role="tab"><img src="/images/graphics/messages.png" width="30" height="30"></a></li> -->
+                <li><a href="#messages" role="tab"><img src="/images/graphics/messages.png" width="30" height="30"></a></li>
 <?php
     if ($numflights > 0) {
         foreach ($flightlist as $row){
@@ -232,37 +232,20 @@
 
 
             <!-- messages sidebar pane (live packet stream) -->
-            <!--
             <div class="sidebar-pane" id="messages">
-                <h1 class="sidebar-header">Live Packet Stream<span class="sidebar-close"><img src="/images/graphics/leftcaret.png" width="30" height="30"></span></h1>
-                <p class="section-header">Live Packet Stream: &nbsp; <span id="livePacketStreamState"><mark style="background-color: red;">off</mark></span></p>
-                <p class="lorem">This tab will display all APRS packets received on today's date for a given flight.  
-                    Packets are displayed in reverse chronological order with the latest packets on top, oldest on bottom.</p>
+                <h1 class="sidebar-header">APRS Messages<span class="sidebar-close"><img src="/images/graphics/leftcaret.png" width="30" height="30"></span></h1>
+                <p class="section-header">APRS Message Packets:</p>
+                <p class="lorem">This tab will display all APRS message packets received on today's date and only those heard over RF.
+                    Packets are displayed in reverse chronological order with the latest packets on top, oldest on bottom.
+                    If an APRS message is addressed directly to you then that message will be <mark>highlighted</mark>.</p>
 
-                <p class="section-header"><a href="#" class="section-link" id="livePacketFlightSelectionLink">(<span style="color: red;" id="livePacketFlightSelectionSign">-</span>) Select flight</a>:</p>
-                <div id="livePacketFlightSelection">
-                    <p class="lorem">To start the packet stream, select a flight, then click start.  Once running, the packet display will be automatically updated every 5 seconds.</p>
-                    <p><span id="flightsLivePacketStream"></span></p>
-                    <p class="section-header"><button name="livepacketstart" id="livepacketstart" >Start</button><button name="livepacketstop" id="livepacketstop">Stop</button></p>
-                </div>
- 
-                <p class="section-header"><a href="#" class="section-link" id="livePacketSearchLink">(<span style="color: red;" id="livePacketSearchSign">-</span>) Search</a>:</p>
-                <div id="livePacketSearch">
-                    <p class="lorem">Enter search characters to filter the displayed packets.  All searches are case insensitive, so "AAA" is equivalent to "aaa".</p>
-                    <p>
-                    <input type="text" size="16" maxlength="128" name="searchfield" id="searchfield" autocomplete="off" autocapitalize="off" spellcheck="false" autocorrect="off">
-                    <select id="operation">
-                        <option value="and" selected="selected">And</option>
-                        <option value="or">Or</option>
-                        <option value="not">Not</option>
-                    </select>
-                    <input type="text" size="16" maxlength="128" name="searchfield2" id="searchfield2" autocomplete="off" autocapitalize="off" spellcheck="false" autocorrect="off" >
-                    </p>
-                    <p><button onclick="clearLivePacketFilters();">Clear</button></p>
-                </div>
-                <p class="section-header">Packets: <mark><span id="packetcount">0</span></mark></p>
-                <div class="packetdata"><p class="packetdata"><span id="packetdata"></span></p></div>
-            </div> -->  <!-- end of messages sidebar pane -->
+                <p class="section-header">Message Packets</p>
+                <!--<div class="packetdata"><p class="packetdata"><span id="packetdata"></span></p></div>-->
+                <div class="packetdata" id="packetdata"></div>
+                <div id="packeterrors"></div>
+            </div> 
+
+            <!-- end of messages sidebar pane -->
 
 
             <!-- settings sidebar pane -->

--- a/www/map.php
+++ b/www/map.php
@@ -241,7 +241,8 @@
 
                 <p class="section-header">Message Packets</p>
                 <!--<div class="packetdata"><p class="packetdata"><span id="packetdata"></span></p></div>-->
-                <div class="packetdata" id="packetdata"></div>
+                <!--<div class="packetdata" id="packetdata"></div>-->
+                <div style="width: 100%; white-space: break-word; word-wrap: break-word; overflow-wrap: break-word;" id="packetdata"></div>
                 <div id="packeterrors"></div>
             </div> 
 

--- a/www/map.php
+++ b/www/map.php
@@ -235,9 +235,12 @@
             <div class="sidebar-pane" id="messages">
                 <h1 class="sidebar-header">APRS Messages<span class="sidebar-close"><img src="/images/graphics/leftcaret.png" width="30" height="30"></span></h1>
                 <p class="section-header">APRS Message Packets:</p>
-                <p class="lorem">This tab will display all APRS message packets received on today's date and only those heard over RF.
-                    Packets are displayed in reverse chronological order with the latest packets on top, oldest on bottom.
-                    If an APRS message is addressed directly to you then that message will be <mark>highlighted</mark>.</p>
+                <p class="lorem">This tab will display all APRS message packets received via RF on today's date.
+                    Packets are displayed in reverse chronological order with the latest packets on top, oldest on bottom.</p>
+                <p class="lorem">Those packets with ARISS in their path are assumed to have come from a satellite digipeater and will 
+                    be denoted with, <mark class="okay" style="white-space: nowrap; word-wrap: nowrap; overflow-wrap: nowrap;">
+                    [ satellite ]</mark>.</p>
+                <p class="lorem">If an APRS message is addressed directly to you then that message will be <mark>highlighted</mark>.</p>
 
                 <p class="section-header">Message Packets</p>
                 <!--<div class="packetdata"><p class="packetdata"><span id="packetdata"></span></p></div>-->

--- a/www/setup.php
+++ b/www/setup.php
@@ -655,7 +655,9 @@ include $documentroot . '/common/header.php';
             <td class="packetlist" id="objectbeaconb" style="text-align: center; white-space: nowrap;">Enable object beaconing: <input type="checkbox" name="objectbeaconing" disabled="disabled" id="objectbeaconing"></td>
         </tr>
 
-		<tr><td class="packetlist" id="beaconingtext9a"><strong>Prepend EOSS to your APRS path</strong> when tracking flights with EOSS.  The system will alway use WIDE1-1,WIDE2-1, but one can optionally can prepend "EOSS" or "EOSSx" to the beginning of that path.  For example, EOSS,WIDE1-1,WIDE2-1. Be mindful not to transmit normal 144.39MHz packets with this option enabled.</td>
+        <tr><td class="packetlist" id="beaconingtext9a"><strong>Prepend EOSS to your APRS path</strong> when tracking flights with EOSS.  The system will alway use WIDE1-1,WIDE2-1, but one can optionally can prepend "EOSS" or "EOSSx" to the beginning of that path.  For example, EOSS,WIDE1-1,WIDE2-1. Be mindful not to transmit normal 144.39MHz packets with this option enabled.
+<br><u>For satellite operations</u>, select <strong>ARISS</strong>, however, for this to be successful the external radio used for transmissions will need to be tuned to 145.825MHz.
+</td>
             <td class="packetlist" id="beaconingtext9b" style="text-align: center; white-space: nowrap;">
             Enable/Disable <input type="checkbox" name="includeeoss" disabled="disabled" id="includeeoss" form="configuration_form" checked onchange="checkEOSS();">
             &nbsp; String: <select form="configuration_form" name="eoss_string" id="eoss_string" disabled="disabled">
@@ -668,6 +670,7 @@ include $documentroot . '/common/header.php';
                 <option value="EOSSF">EOSSF</option>
                 <option value="EOSSG">EOSSG</option>
                 <option value="EOSSX">EOSSX</option>
+                <option value="ARISS">ARISS</option>
             </select>
             </td>
         </tr>


### PR DESCRIPTION
This change provides a convenient way display APRS message packets that the system has received over RF (i.e. from direwolf).  Those APRS message packets that have been heard on the current day will be displayed as a list within a new tab on the sidebar on the map.  If ARISS appears in their path they will be denoted as "Satellite".  For those packets that are addressed to the current user (or rather the callsign of the user using the system), those will be highlighted in yellow.

In addition, under Setup->System Configuration, within the Beaconing section, one can now choose "ARISS" as a prefix to any transmitted APRS packets from the brick.  This assumes of course, that the user has connected the brick to an external radio through a Rig Blaster, Signalink, or similar device.  The idea being that the user might have the external radio tuned to 145.825MHz for satellite work (i.e. digipeating one's APRS transmission off of PSAT2, the ISS, etc.).