### PR TITLE
Adjust direwolf audio rates for RTLSDR dongles down to 44.1k and better report airspy supported rates

### DIFF
--- a/bin/aprsreceiver.py
+++ b/bin/aprsreceiver.py
@@ -94,8 +94,17 @@ class aprs_receiver(gr.top_block):
         if prefix == "airspy":
             self.direwolf_audio_rate = 50000
 
+            # Get the list of supported sample rates from the Airspy device
+            rates = self.osmosdr_source_0.get_sample_rates()
+
+            # Report sample rates supported by the Airspy device
+            s = "Airspy supported sample rates: "
+            for r in rates:
+                s += "  " + str(int(r.start()))
+            print s
+
             # Get the first valid sample rate for the airspy device.  This *should* be the lowest sample rate allowed by the device.
-            self.samp_rate = self.osmosdr_source_0.get_sample_rates()[0].start()
+            self.samp_rate = int(rates[0].start())
 
             # Turn off hardware AGC
             self.osmosdr_source_0.set_gain_mode(False, 0)

--- a/bin/aprsreceiver.py
+++ b/bin/aprsreceiver.py
@@ -107,10 +107,10 @@ class aprs_receiver(gr.top_block):
 
         # Not an airspy device...so we set sample rates and parameters as multiples of a 48k audio sample rate that direwolf will use
         else: 
-            self.direwolf_audio_rate = 48000
+            self.direwolf_audio_rate = 44100
 
             # For the determined center frequency (above) we find the maximum distance between it and the freqs we're listening too.   Multiple that "spread" by two, 
-            # then round up to the nearest multiple of the direwolf audio rate (i.e. 48k).  The idea being we want a sample rate that is 2 x the max spread between 
+            # then round up to the nearest multiple of the direwolf audio rate (i.e. 48k, 44.1k, etc.).  The idea being we want a sample rate that is 2 x the max spread between 
             # the center frequency and all those we're listening too.   We choose 2x because of nyquist.
             spread = int(math.ceil(max_d(freqs, self.center_freq) * 2.0 / self.direwolf_audio_rate) * self.direwolf_audio_rate)
 

--- a/bin/direwolf.py
+++ b/bin/direwolf.py
@@ -65,7 +65,7 @@ def createDirewolfConfig(callsign, l, configdata, gpsposition):
                     if prefix == "airspy":
                         f.write("ARATE 50000\n")
                     else:
-                        f.write("ARATE 48000\n")
+                        f.write("ARATE 44100\n")
 
                     f.write("ACHANNELS 1\n")
                     f.write("CHANNEL " + str(channel) + "\n")
@@ -104,7 +104,7 @@ def createDirewolfConfig(callsign, l, configdata, gpsposition):
                 f.write("###########################################\n\n")
                 f.write("# This is the external radio connection\n")
                 f.write("ADEVICE" + str(adevice) + " plughw:" + str(configdata["audiodev"]) + ",0\n")
-                f.write("ARATE 48000\n")
+                f.write("ARATE 44100\n")
                 f.write("ACHANNELS 1\n")
                 f.write("CHANNEL " + str(channel) + "\n")
                 f.write("MYCALL " + callsign + "\n")


### PR DESCRIPTION
For 1200baud APRS reception an audio sample rate of 44.1k is more than enough to ensure proper reception.  For RTL-SDR devices the direwolf audio rate is set down to 44100 from 48000 to help ease CPU usage.  For fixed sample rate devices like the Airspy, the direwolf audio rate is still using 50000 as it's an even multiple of the 2.5M, 3M, 6M, and 10M sample rates that those devices provide.