### PR TITLE
Remove from all PHP files the use of session_start()

### DIFF
--- a/www/about.php
+++ b/www/about.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 $pagetitle="APRS:  About";
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/addbeacon.php
+++ b/www/addbeacon.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/addflight.php
+++ b/www/addflight.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/addfrequency.php
+++ b/www/addfrequency.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/addlaunchsite.php
+++ b/www/addlaunchsite.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/addpredictiondata.php
+++ b/www/addpredictiondata.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
     $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
 else

--- a/www/addtracker.php
+++ b/www/addtracker.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/changeassignedflight.php
+++ b/www/changeassignedflight.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/changelaunchsite.php
+++ b/www/changelaunchsite.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/changetrackerteam.php
+++ b/www/changetrackerteam.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/common/database.php
+++ b/www/common/database.php
@@ -23,7 +23,6 @@
 *
 */
 
-if(session_status() === PHP_SESSION_NONE) session_start();
 
 /* Read the configuration info */
 

--- a/www/dashboard.php
+++ b/www/dashboard.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 $pagetitle="APRS:  Dashboard";
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/deletebeacon.php
+++ b/www/deletebeacon.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/deleteflight.php
+++ b/www/deleteflight.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/deletefrequency.php
+++ b/www/deletefrequency.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
             $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/deletelaunchsite.php
+++ b/www/deletelaunchsite.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/deleteoldpredicts.php
+++ b/www/deleteoldpredicts.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
     $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
 else

--- a/www/deletetracker.php
+++ b/www/deletetracker.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/downloaddata.php
+++ b/www/downloaddata.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getactiveflights.php
+++ b/www/getactiveflights.php
@@ -25,7 +25,6 @@
 
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getairdensity.php
+++ b/www/getairdensity.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getallpackets.php
+++ b/www/getallpackets.php
@@ -26,7 +26,6 @@
     ###  This will query the database for the n most recent packets.  
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getallstations.php
+++ b/www/getallstations.php
@@ -26,7 +26,6 @@
     ###  This will query the database for the n most recent packets.  
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getaltitudechartdata.php
+++ b/www/getaltitudechartdata.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getaudioalerts.php
+++ b/www/getaudioalerts.php
@@ -28,7 +28,6 @@
 #
 # This will return JSON of the form:  {"flightid" : "abcd-xxx", "audiofile" : "filename" }
 
-    session_start();
     header("Content-Type:  application/json;");
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/getaudiodevs.php
+++ b/www/getaudiodevs.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getconfiguration.php
+++ b/www/getconfiguration.php
@@ -25,7 +25,6 @@
 
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getdashboardpackets.php
+++ b/www/getdashboardpackets.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     header("Content-Type:  application/json;");
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/getdirewolfperformance.php
+++ b/www/getdirewolfperformance.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getflightdata.php
+++ b/www/getflightdata.php
@@ -25,7 +25,6 @@
 
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getflightpackets.php
+++ b/www/getflightpackets.php
@@ -24,7 +24,6 @@
  */
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getflights.php
+++ b/www/getflights.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getflightsformap.php
+++ b/www/getflightsformap.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getfrequencies.php
+++ b/www/getfrequencies.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getgps.php
+++ b/www/getgps.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getheadingvsaltitude.php
+++ b/www/getheadingvsaltitude.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getlandingpredictions.php
+++ b/www/getlandingpredictions.php
@@ -24,7 +24,6 @@
  */
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getlaunchsites.php
+++ b/www/getlaunchsites.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getlogs.php
+++ b/www/getlogs.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getmystation.php
+++ b/www/getmystation.php
@@ -26,7 +26,6 @@
     ###  This will query the database for the n most recent packets.  
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getotherdata.php
+++ b/www/getotherdata.php
@@ -24,7 +24,6 @@
  */
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getpackethashes.php
+++ b/www/getpackethashes.php
@@ -25,7 +25,6 @@
 
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getpacketperformance.php
+++ b/www/getpacketperformance.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getpackets.php
+++ b/www/getpackets.php
@@ -25,7 +25,6 @@
 
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getposition.php
+++ b/www/getposition.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getpositionpackets.php
+++ b/www/getpositionpackets.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getpredictionpaths.php
+++ b/www/getpredictionpaths.php
@@ -25,7 +25,6 @@
 
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getpredictions.php
+++ b/www/getpredictions.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getpressure.php
+++ b/www/getpressure.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getrelativeposition.php
+++ b/www/getrelativeposition.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getrfstations.php
+++ b/www/getrfstations.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getserialports.php
+++ b/www/getserialports.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getspeedvsaltitude.php
+++ b/www/getspeedvsaltitude.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getstatus.php
+++ b/www/getstatus.php
@@ -24,7 +24,6 @@
  */
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getstatuspackets.php
+++ b/www/getstatuspackets.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getteams.php
+++ b/www/getteams.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/gettemp.php
+++ b/www/gettemp.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/gettemppressure.php
+++ b/www/gettemppressure.php
@@ -25,7 +25,6 @@
 
     ###  This will query the database for the n most recent packets.  
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/gettimezones.php
+++ b/www/gettimezones.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/gettrackercountstable.php
+++ b/www/gettrackercountstable.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/gettrackers.php
+++ b/www/gettrackers.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/gettrackerstations.php
+++ b/www/gettrackerstations.php
@@ -24,7 +24,6 @@
  */
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getttl.php
+++ b/www/getttl.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getupdates.php
+++ b/www/getupdates.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getverticalvsaltitude.php
+++ b/www/getverticalvsaltitude.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getvertratechartdata.php
+++ b/www/getvertratechartdata.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/getweatherstations.php
+++ b/www/getweatherstations.php
@@ -24,7 +24,6 @@
  */
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/grabprediction.php
+++ b/www/grabprediction.php
@@ -25,7 +25,6 @@
 
 
 header("Content-Type:  application/json;");
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/index.php
+++ b/www/index.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 $pagetitle="APRS:  Home";
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/map.php
+++ b/www/map.php
@@ -24,7 +24,6 @@
  */
 
 
-    session_start();
     $pagetitle="APRS:  Map";
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/monitor.php
+++ b/www/monitor.php
@@ -24,7 +24,6 @@
  */
 
 $pagetitle="APRS: Monitor";
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/rawdata.php
+++ b/www/rawdata.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 $pagetitle="APRS:  Data";
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/readconfiguration.php
+++ b/www/readconfiguration.php
@@ -23,7 +23,6 @@
 *
 */
 
-    if(session_status() === PHP_SESSION_NONE) session_start();
 
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/rmpredictiondata.php
+++ b/www/rmpredictiondata.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/setconfiguration.php
+++ b/www/setconfiguration.php
@@ -23,7 +23,6 @@
 *
 */
 
-    if(session_status() === PHP_SESSION_NONE) session_start();
 
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/setup.php
+++ b/www/setup.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 $pagetitle="APRS:  Setup";
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];

--- a/www/shutdown.php
+++ b/www/shutdown.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/startup.php
+++ b/www/startup.php
@@ -23,7 +23,6 @@
 *
  */
 
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/syncconfiguration.php
+++ b/www/syncconfiguration.php
@@ -24,7 +24,6 @@
  */
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/syncpackets.php
+++ b/www/syncpackets.php
@@ -25,7 +25,6 @@
 
 
     header("Content-Type:  application/json;");
-    session_start();
     if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else

--- a/www/trackflight.php
+++ b/www/trackflight.php
@@ -24,7 +24,6 @@
  */
 
 
-session_start();
 if (array_key_exists("CONTEXT_DOCUMENT_ROOT", $_SERVER))
         $documentroot = $_SERVER["CONTEXT_DOCUMENT_ROOT"];
     else


### PR DESCRIPTION
Removing this should make web page loading a bit snappier and prevent the backend from serializing page loads from a single browser because it locks/unlocks the session file when PHP calls session_start().