### PR TITLE
Adjust airspy sample rates and standardize on 50k for direwolf’s audio sample rate

### DIFF
--- a/bin/aprsreceiver.py
+++ b/bin/aprsreceiver.py
@@ -182,16 +182,16 @@ class aprs_receiver(gr.top_block):
         self.downstream_samp_rate = None
 
         # Airspy R2 / Mini can only accommodate specific sample rates and uses device specific RF gains, so we need to adjust values to accommodate
+        airspy_rates_string = ""
         if prefix == "airspy":
 
             # Get the list of supported sample rates from the Airspy device
             rates = self.osmosdr_source_0.get_sample_rates()
 
             # Report sample rates supported by the Airspy device
-            s = "Airspy supported sample rates: "
+            airspy_rates_string = "Airspy supported sample rates: "
             for r in rates:
-                s += "  " + str(int(r.start()))
-            print s
+                airspy_rates_string += "  " + str(int(r.start()))
 
             # Get the first valid sample rate for the airspy device.  This *should* be the lowest sample rate allowed by the device.
             self.samp_rate = int(rates[0].start())
@@ -315,24 +315,37 @@ class aprs_receiver(gr.top_block):
             self.connect((analog_agc, 0), (blocks_float_to_short, 0))
             self.connect((blocks_float_to_short, 0), (blocks_udp_sink, 0))
 
-        print "GnuRadio parameters for:  ", self.rtl_id
-        print "len(channel taps):  ", len(self.channel_lowpass_taps)
-        print "len(audio taps):  ", len(self.audio_taps)
-        print "Source sample rate (", self.rtl_id, "):  ", self.samp_rate
-        print "Downstream sample rate (", self.rtl_id, "):  ", self.downstream_samp_rate
-        #print "Channel width (Hz):  ", self.channel_width
-        print "Direwolf audio rate:  ", self.direwolf_audio_rate
-        print "Quadrature rate:  ", self.quadrate
-        print "Frequency spread:  ", spread
-        print "Center frequency(", self.rtl_id, "):  ", self.center_freq
-        print "Xlating decimation:  ", self.decimation
+        print "==== GnuRadio parameters ===="
+        instance_string = "    " + str(self.rtl_id) + ":  "
+        if prefix == "airspy": 
+            print "    Processing chain:"
+            print "        osmosdr_source (" + self.rtl_id + ") --> rational_resampler --> xlating_fir_filter (channel taps) --> quad_demod --> fm_deemphasis -->"
+            print "        audio_lowpass_filter (audio taps) --> agc --> float_to_short --> UDP_sink"
+        else:
+            print "    Processing chain:"
+            print "        osmosdr_source (" + self.rtl_id + ") --> xlating_fir_filter (channel taps) --> quad_demod --> fm_deemphasis -->"
+            print "        audio_lowpass_filter (audio taps) --> agc --> float_to_short --> UDP_sink"
+        print instance_string, "len(channel taps):   ", len(self.channel_lowpass_taps)
+        print instance_string, "len(audio taps):     ", len(self.audio_taps)
+        print instance_string, "Source sample rate:  ", self.samp_rate
+        print instance_string, "Downstrm samp rate:  ", self.downstream_samp_rate
+        print instance_string, "Channel width (Hz):  ", self.channel_width
+        print instance_string, "Dwolf audio rate:    ", self.direwolf_audio_rate
+        print instance_string, "Quadrature rate:     ", self.quadrate
+        print instance_string, "Frequency spread:    ", spread
+        print instance_string, "Center frequency:    ", self.center_freq
+        print instance_string, "Xlating decimation:  ", self.decimation
 
-        # Query the osmosdr block to determine just what gain and sample rates it set for the airspy device
         if prefix == "airspy":
-            print "Airspy LNA Gain set to:  ", self.osmosdr_source_0.get_gain("LNA")
-            print "Airspy MIX Gain set to:  ", self.osmosdr_source_0.get_gain("MIX")
-            print "Airspy VGA Gain set to:  ", self.osmosdr_source_0.get_gain("IF")
-            print "Airspy source sample rate set to:  ", self.samp_rate
+            print instance_string, "Airspy LNA Gain:     ", self.osmosdr_source_0.get_gain("LNA")
+            print instance_string, "Airspy MIX Gain:     ", self.osmosdr_source_0.get_gain("MIX")
+            print instance_string, "Airspy VGA Gain:     ", self.osmosdr_source_0.get_gain("IF")
+            print instance_string, airspy_rates_string
+            print instance_string, "Airspy source sample rate set to:  ", self.samp_rate
+        else:
+            print instance_string, "Gain mode:           ", "automatic"
+
+        print "============================="
 
         sys.stdout.flush()
 

--- a/bin/aprsreceiver.py
+++ b/bin/aprsreceiver.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 ##################################################
 #    This file is part of the HABTracker project for tracking high altitude balloons.
 #
@@ -33,11 +34,87 @@ import math
 
 
 ##################################################
+# gcd
+#    find greatest common divsor
+##################################################
+def gcd(a, b):
+    if a == 0:
+        return b
+    elif b == 0:
+        return a
+    
+    if a < b:
+        return gcd(a, b % a)
+    else:
+        return gcd(b, a % b)
+
+
+##################################################
+# decimalToFraction
+#    return the fraction that represents the decimal number
+##################################################
+def decimalToFraction(number):
+
+    # integer value 
+    intval = math.floor(number)
+
+    # fractional value
+    fval = number - intval
+
+    # precision
+    p = 1000000
+
+    # calculate the gcd value
+    gcdvalue = gcd(round(fval * p), p)
+
+    # the numerator
+    num = int(round(fval * p) / gcdvalue)
+
+    # the denominator
+    den = int(p / gcdvalue)
+
+    return (num, den)
+
+
+##################################################
+# getResamplerFactors
+#    For a given sample and audio rates then return the numerator and denominator of a fraction for reducing the sample rate
+#    to a number close to the spread as a multiple of the audio rate
+##################################################
+def getResamplerFactors(sample_rate, spread, audio_rate):
+
+    multiple = int(math.ceil(float(spread) / audio_rate))
+    if multiple % 2:
+        multiple = multiple + 1
+
+    decimal = (audio_rate * multiple) / float(sample_rate)
+    n, d = decimalToFraction(decimal)
+    return (n, d, multiple)
+
+
+##################################################
+# getRTLSampleRate
+#    This inputs a given sample rate and the direwolf audio rate and outputs a new rate that is a multiple of the direwolf audio rate
+##################################################
+
+def getRTLSampleRate(samplerate, audiorate):
+
+    # get the multiple vs. the direwolf audio rate
+    n = int(math.ceil(float(samplerate) / float(audiorate)))
+
+    # make sure we're using an even multiple of the direwolf audio rate (for nice decimations later on)
+    if n % 2:
+        n = n + 1
+
+    return int(audiorate * n)
+
+
+##################################################
 # aprs_receiver class:
 #    This is the process that listens on various frequencies
 ##################################################
 class aprs_receiver(gr.top_block):
-    def __init__(self, freqlist=[[144390000, 12000, "rtl", "n/a"]], rtl=0, prefix="rtl"):
+    def __init__(self, freqlist=[[144390000, 12000, "rtl", "n/a"]], rtl=0, prefix="rtl", ip = '127.0.0.1', samplerate = 48000):
         gr.top_block.__init__(self, "APRS Receiver for Multiple Frequencies")
 
         self.Frequencies = freqlist
@@ -90,9 +167,22 @@ class aprs_receiver(gr.top_block):
         # set the source block's center frequency now that we know that.
         self.osmosdr_source_0.set_center_freq(self.center_freq, 0)
 
+        # The direwolf audio rate. 
+        self.direwolf_audio_rate = samplerate
+
+        # For the determined center frequency (above) we find the maximum distance between it and the freqs we're listening too.   Multiply that "spread" by two, 
+        # then round up to the nearest multiple of the direwolf audio rate (i.e. 48k, 44.1k, etc.).  The idea being we want a sample rate that is 2 x the max spread between 
+        # the center frequency and all those we're listening too.   We choose 2x because of nyquist.
+        spread = int(math.ceil(max_d(freqs, self.center_freq) * 2.0 / self.direwolf_audio_rate) * self.direwolf_audio_rate)
+
+        # resampler for the airspy to get the direwolf sample rate down to 44k
+        self.rational_resampler = None
+
+        # downstream sample rate for blocks south of the Osmocom source or the rational resampler in the case of an airspy dongle
+        self.downstream_samp_rate = None
+
         # Airspy R2 / Mini can only accommodate specific sample rates and uses device specific RF gains, so we need to adjust values to accommodate
         if prefix == "airspy":
-            self.direwolf_audio_rate = 50000
 
             # Get the list of supported sample rates from the Airspy device
             rates = self.osmosdr_source_0.get_sample_rates()
@@ -114,56 +204,42 @@ class aprs_receiver(gr.top_block):
             self.osmosdr_source_0.set_gain(12, 'MIX', 0)
             self.osmosdr_source_0.set_gain(13,  'IF',  0)
 
-        # Not an airspy device...so we set sample rates and parameters as multiples of a 48k audio sample rate that direwolf will use
-        else: 
-            self.direwolf_audio_rate = 44100
+            # We need to determine a sample rate that is a multiple of the direwolf audio rate (ex. 44k), then from that, we can determine 
+            numerator, denominator, n = getResamplerFactors(self.samp_rate, spread, self.direwolf_audio_rate)
 
-            # For the determined center frequency (above) we find the maximum distance between it and the freqs we're listening too.   Multiple that "spread" by two, 
-            # then round up to the nearest multiple of the direwolf audio rate (i.e. 48k, 44.1k, etc.).  The idea being we want a sample rate that is 2 x the max spread between 
-            # the center frequency and all those we're listening too.   We choose 2x because of nyquist.
-            spread = int(math.ceil(max_d(freqs, self.center_freq) * 2.0 / self.direwolf_audio_rate) * self.direwolf_audio_rate)
+            # The downstream sample rate (i.e. used by blocks south of the rational resampler)
+            self.downstream_samp_rate = self.direwolf_audio_rate * n
+
+            # resampler to get the sample rate down to something that will fit nicely with a 44k audio rate to direwolf
+            self.rational_resampler = filter.rational_resampler_ccc(
+                interpolation=numerator,
+                decimation=denominator,
+                taps=None,
+                fractional_bw=None,
+            )
+
+        # Not an airspy device...so we set sample rates and parameters as multiples of the 44k audio sample rate that direwolf will use
+        else: 
 
             # Now check if our calculated sample rate falls within the allowed sample rates for the RTL-SDR device.
             # For reference, valid sample rates for RTL-SDR dongles:
             # 225001 to 300000 and 900001 to 3200000
             if spread < 225001:
-
-                # get the multiple vs. the direwolf audio rate
-                n = int(math.ceil(225001.0 / self.direwolf_audio_rate))
-
-                # make sure we're using an even multiple of the direwolf audio rate (for nice decimations later on)
-                if n % 2:
-                    n = n + 1
-
-                # set the sample rate
-                self.samp_rate = self.direwolf_audio_rate * n
+                self.samp_rate = getRTLSampleRate(225001, self.direwolf_audio_rate)
 
             elif spread > 2200000:
-
-                # get the multiple vs. the direwolf audio rate
-                n = int(math.ceil(2200000.0 / self.direwolf_audio_rate))
-
-                # make sure we're using an even multiple of the direwolf audio rate (for nice decimations later on)
-                if n % 2:
-                    n = n + 1
-
-                # set the sample rate
-                self.samp_rate = self.direwolf_audio_rate * n
+                self.samp_rate = getRTLSampleRate(22000000, self.direwolf_audio_rate)
 
             elif 300000 < spread < 900001:
+                self.samp_rate = getRTLSampleRate(900001, self.direwolf_audio_rate)
                 
-                # get the multiple vs. the direwolf audio rate
-                n = int(math.ceil(900001.0 / self.direwolf_audio_rate))
+            else:
+                self.samp_rate = getRTLSampleRate(spread, self.direwolf_audio_rate)
 
-                # make sure we're using an even multiple of the direwolf audio rate (for nice decimations later on)
-                if n % 2:
-                    n = n + 1
 
-                # set the sample rate
-                self.samp_rate = self.direwolf_audio_rate * n
-
-            else:   # otherwise, we're good
-                self.samp_rate = spread
+            # the "samp_rate" variable is used to set the sample rate for the source block, however, all downstream blocks will use the "downtream_samp_rate"
+            # For RTLSDR dongles, these are the same (because the valid sample rates for the RTL device can be largely user defined).
+            self.downstream_samp_rate = self.samp_rate
 
             # Turn on hardware AGC
             self.osmosdr_source_0.set_gain_mode(True, 0)
@@ -185,7 +261,7 @@ class aprs_receiver(gr.top_block):
             self.channel_cutoff_freq = 2200 + self.max_deviation
 
         # FM channel low pass filter taps
-        self.channel_lowpass_taps = firdes.low_pass(1, self.samp_rate, self.channel_cutoff_freq, self.channel_transition_width, firdes.WIN_HANN, 6.76)
+        self.channel_lowpass_taps = firdes.low_pass(1, self.downstream_samp_rate, self.channel_cutoff_freq, self.channel_transition_width, firdes.WIN_HANN, 6.76)
 
         # Quadrature rate (input rate for the quadrature demod block)
         self.quadrate = self.direwolf_audio_rate * 2
@@ -194,7 +270,7 @@ class aprs_receiver(gr.top_block):
         self.audio_decim = self.quadrate / self.direwolf_audio_rate
 
         # Decimation factor for the xlating_fir_filter block
-        self.decimation = self.samp_rate / (self.audio_decim * self.direwolf_audio_rate)
+        self.decimation = self.downstream_samp_rate / (self.audio_decim * self.direwolf_audio_rate)
 
         # Audio Low pass filter parameters.  We want a lazy transition to minimize filter taps and CPU usage.
         self.transition_width = 1000
@@ -205,6 +281,10 @@ class aprs_receiver(gr.top_block):
         # Audio low pass filter taps.  
         self.audio_taps = firdes.low_pass(1, self.quadrate, self.lowpass_freq, self.transition_width, fft.window.WIN_HAMMING)  
 
+        # If we're using an airspy device, then we need to resample the sample rate to a value that is a nice multiple of the direwolf audio rate (ex. 44k)
+        if prefix == "airspy" and self.rational_resampler:
+            self.connect((self.osmosdr_source_0, 0), (self.rational_resampler, 0))
+
         # Now construct a seperate processing chain for each frequency we're listening to.
         # processing chain:
         #    osmosdr_source ---> xlating_fir_filter ---> quad_demod ---> fm_deemphasis ---> audio_lowpass_filter ---> agc ---> float_to_short ---> UDP_sink
@@ -212,8 +292,8 @@ class aprs_receiver(gr.top_block):
         for freq,port,p,sn in self.Frequencies:
             #print "   channel:  [%d] %dMHz" % (port, freq)
             #print "   quadrate:  %d" % (self.quadrate)
-            freq_xlating_fir_filter = filter.freq_xlating_fir_filter_ccf(self.decimation, (self.channel_lowpass_taps), freq-self.center_freq, self.samp_rate)
-            blocks_udp_sink = blocks.udp_sink(gr.sizeof_short*1, '127.0.0.1', port, self.mtusize, True)
+            freq_xlating_fir_filter = filter.freq_xlating_fir_filter_ccf(self.decimation, (self.channel_lowpass_taps), freq-self.center_freq, self.downstream_samp_rate)
+            blocks_udp_sink = blocks.udp_sink(gr.sizeof_short*1, ip, port, self.mtusize, True)
             blocks_float_to_short = blocks.float_to_short(1, self.scale)
             quad_demod = analog.quadrature_demod_cf(self.quadrate/(2*math.pi*self.max_deviation/8.0))
             fmdeemphasis = analog.fm_deemph(self.quadrate)
@@ -224,7 +304,10 @@ class aprs_receiver(gr.top_block):
             ##################################################
             # Connections
             ##################################################
-            self.connect((self.osmosdr_source_0, 0), (freq_xlating_fir_filter, 0))
+            if prefix == "airspy" and self.rational_resampler:
+                self.connect((self.rational_resampler, 0), (freq_xlating_fir_filter, 0))
+            else:
+                self.connect((self.osmosdr_source_0, 0), (freq_xlating_fir_filter, 0))
             self.connect((freq_xlating_fir_filter, 0), (quad_demod, 0))
             self.connect((quad_demod, 0), (fmdeemphasis, 0))
             self.connect((fmdeemphasis, 0), (audio_filter, 0))
@@ -235,19 +318,21 @@ class aprs_receiver(gr.top_block):
         print "GnuRadio parameters for:  ", self.rtl_id
         print "len(channel taps):  ", len(self.channel_lowpass_taps)
         print "len(audio taps):  ", len(self.audio_taps)
-        print "Sample rate (", self.rtl_id, "):  ", self.samp_rate
+        print "Source sample rate (", self.rtl_id, "):  ", self.samp_rate
+        print "Downstream sample rate (", self.rtl_id, "):  ", self.downstream_samp_rate
         #print "Channel width (Hz):  ", self.channel_width
-        #print "Direwolf audio rate:  ", self.direwolf_audio_rate
-        #print "Quadrature rate:  ", self.quadrate
+        print "Direwolf audio rate:  ", self.direwolf_audio_rate
+        print "Quadrature rate:  ", self.quadrate
+        print "Frequency spread:  ", spread
         print "Center frequency(", self.rtl_id, "):  ", self.center_freq
-        #print "Xlating decimation:  ", self.decimation
+        print "Xlating decimation:  ", self.decimation
 
         # Query the osmosdr block to determine just what gain and sample rates it set for the airspy device
         if prefix == "airspy":
             print "Airspy LNA Gain set to:  ", self.osmosdr_source_0.get_gain("LNA")
             print "Airspy MIX Gain set to:  ", self.osmosdr_source_0.get_gain("MIX")
             print "Airspy VGA Gain set to:  ", self.osmosdr_source_0.get_gain("IF")
-            print "Airspy sample rate set to:  ", self.samp_rate
+            print "Airspy source sample rate set to:  ", self.samp_rate
 
         sys.stdout.flush()
 
@@ -255,13 +340,13 @@ class aprs_receiver(gr.top_block):
 # GRProcess:
 #    - Then starts up an instance of the aprs_receiver class
 ##################################################
-def GRProcess(flist=[[144390000, 12000, "rtl", "n/a"]], rtl=0, prefix="rtl", e = None):
+def GRProcess(flist=[[144390000, 12000, "rtl", "n/a"]], rtl=0, prefix="rtl", ip_dest = '127.0.0.1', rate = 48000, e = None):
     try:
 
         #print "GR [%d], listening on: " % rtl, flist
 
         # create an instance of the aprs receiver class
-        tb = aprs_receiver(freqlist=flist, rtl=rtl, prefix=prefix)
+        tb = aprs_receiver(freqlist=flist, rtl=rtl, prefix=prefix, ip=ip_dest, samplerate=rate)
 
         # call its "run" method...this blocks until done
         tb.start()
@@ -273,6 +358,5 @@ def GRProcess(flist=[[144390000, 12000, "rtl", "n/a"]], rtl=0, prefix="rtl", e =
     except (KeyboardInterrupt, SystemExit):
         tb.stop()
         print "GnuRadio ended"
-
 
 

--- a/bin/direwolf.py
+++ b/bin/direwolf.py
@@ -61,11 +61,8 @@ def createDirewolfConfig(callsign, l, configdata, gpsposition):
                     f.write("# SDR Device: " + prefix + " (s/n: " + sn + ")  Frequency: " + str(round(freq/1000000.0, 3)) + "MHz\n")
                     f.write("ADEVICE" + str(adevice) + " udp:" + str(port) + " null\n")
 
-                    # Airspy SDRs require us to use an audio rate of 50k (it's because those dongles support limited sample rates)
-                    if prefix == "airspy":
-                        f.write("ARATE 50000\n")
-                    else:
-                        f.write("ARATE 44100\n")
+                    # Defaulting to an audio rate of 50000.  Fixing this makes it easier on the GnuRadio receiver side when working with resampling.
+                    f.write("ARATE 50000\n")
 
                     f.write("ACHANNELS 1\n")
                     f.write("CHANNEL " + str(channel) + "\n")

--- a/bin/habtracker-daemon.py
+++ b/bin/habtracker-daemon.py
@@ -703,8 +703,15 @@ def main():
                 # append this frequency/UDP port list to the list for Direwolf
                 direwolfFreqList.append(freqlist)
 
+                # The IP destination for where the GnuRadio UDP network block is to send its audio packets too.  This is hard coded to be the loopback address (for now).
+                ip_dest = "127.0.0.1"
+
+                # The direwolf audio sample rate.  This is hardcoded for now to be 50000 as it makes the math easier for the Resampler blocks within the GnuRadio receiver.
+                # This primaryly comes into play with airspy dongles as they have a fixed sample rate that is a nice multiple of 50000.
+                samplerate = 50000
+
                 # This is the GnuRadio process
-                grprocess = mp.Process(target=aprsreceiver.GRProcess, args=(freqlist, int(k["rtl"]), k["prefix"], stopevent))
+                grprocess = mp.Process(target=aprsreceiver.GRProcess, args=(freqlist, int(k["rtl"]), k["prefix"], ip_dest, samplerate, stopevent))
                 grprocess.daemon = True
                 grprocess.name = "GnuRadio_" + str(k["rtl"])
                 processes.append(grprocess)

--- a/bin/kiss.py
+++ b/bin/kiss.py
@@ -233,7 +233,6 @@ class KISS(object):
 
                             for f in frames:
                                 try:
-
                                     channel = ord(f[0]) >> 4
 
                                     # Strip off the first byte, as that's the KISS data frame byte
@@ -246,8 +245,8 @@ class KISS(object):
                                     callback(packet, channel)
 
                                 except Exception as e:
-                                    print "error (", e, ") parsing packet: ", f
-                                    sys.stdout.flush()
+                                    # we skip any frames that have some sort of issue...
+                                    pass
 
                             kiss_frames = []
                         else:

--- a/bin/kiss.py
+++ b/bin/kiss.py
@@ -232,16 +232,22 @@ class KISS(object):
                             # ..
 
                             for f in frames:
-                                channel = ord(f[0]) >> 4
+                                try:
 
-                                # Strip off the first byte, as that's the KISS data frame byte
-                                s = f[1:]
-                                s = s.strip(chr(KISS_FEND))
+                                    channel = ord(f[0]) >> 4
 
-                                packet = self.parseFrame(s)
+                                    # Strip off the first byte, as that's the KISS data frame byte
+                                    s = f[1:]
+                                    s = s.strip(chr(KISS_FEND))
 
-                                debugmsg("calling function for: [{}] {}\n".format(channel, s))
-                                callback(packet, channel)
+                                    packet = self.parseFrame(s)
+
+                                    debugmsg("calling function for: [{}] {}\n".format(channel, s))
+                                    callback(packet, channel)
+
+                                except Exception as e:
+                                    print "error (", e, ") parsing packet: ", f
+                                    sys.stdout.flush()
 
                             kiss_frames = []
                         else:

--- a/www/common/index.js
+++ b/www/common/index.js
@@ -173,9 +173,14 @@ function getrecentdata() {
         var freqhtml = "";
         var callsign_html = "";
         //document.getElementById("debug").innerHTML = JSON.stringify(frequencies);
+        //
+
+        var product_name_lower = antennas[i].rtl_product.toLowerCase();
+        var instancename = (product_name_lower.includes("rtl") ? "rtl" : (product_name_lower.includes("airspy") ? "airspy" : "rtl"))
 
         for (k = 0; k < frequencies.length; k++) 
             freqhtml = freqhtml + frequencies[k].frequency.toFixed(3) + "MHz &nbsp; (" + frequencies[k].udp_port + ")<br>"; 
+
         antenna_html = antenna_html + "<div style=\"float: left\"><div class=\"antenna\" style=\"float: left;\"><img src=\"/images/graphics/antenna.png\" style=\"height: 150px;\"></div>"
             + "<div class=\"antenna-table\">"
             + "<div class=\"table-row\">"
@@ -192,7 +197,7 @@ function getrecentdata() {
             + "</div>"
             + "<div class=\"table-row\">"
             + "    <div class=\"table-cell\">SDR Information</div>"
-            + "    <div class=\"table-cell\" style=\"text-align: right;\">RTL-SDR #: " + rtl_id + "<br>Product: " + antennas[i].rtl_product + "<br>Manufacturer: " + antennas[i].rtl_manufacturer  + "<br>Serial No: " + antennas[i].rtl_serialnumber + "</div>"
+            + "    <div class=\"table-cell\" style=\"text-align: right;\">" + instancename + " = " + rtl_id + "<br>Product: " + antennas[i].rtl_product + "<br>Manufacturer: " + antennas[i].rtl_manufacturer  + "<br>Serial No: " + antennas[i].rtl_serialnumber + "</div>"
             + "</div>"
             + "<div class=\"table-row\">"
             + "    <div class=\"table-cell\">Igating Status</div>"


### PR DESCRIPTION
When using an Airspy dongle, the sample rates available (they’re hard set by the driver) are typically much higher than necessary for 2m APRS.  Compared to RTLSDR dongles, one can set the sample rate to a variable number that subsequently allows for a reduced overall sample rate and a lower overall CPU usage.  

This update inserts a “rational resampler” block post- the Osmocom source block when using an Airspy dongle.  Doing this reduces the overall sample rate for all downstream blocks and consequently results in lower overall CPU usage.  In tests, this results in a savings of ~10% CPU utilization without any adverse APRS demodulation impact (dependent on the type of Airspy dongle.  Ex. AirspyR2, AirspyMini, etc.).

In addition, this change standardizes on 50k as the sample rate that direwolf will use for any audio streams output from the GnuRadio front end.  It turns out, there is little impact on CPU usage between 44100, 48000, and 50000 audio sample rates with direwolf.  Okay, obviously there is a small uptick in CPU usage with higher audio sample rates, but its very small with < 7 processing chains.