### PR TITLE
Changes to enable running aprsc instead of in-house igating/etc..

### DIFF
--- a/bin/habtracker-daemon.py
+++ b/bin/habtracker-daemon.py
@@ -77,7 +77,6 @@ def signal_handler(signum, frame):
     raise GracefulExit()
 
 
-
 ##################################################
 # argument_parser function...This will parse through any command line options given and return the options
 ##################################################
@@ -321,7 +320,13 @@ def createProcesses(configuration):
     landingprocess.daemon = True
     procs.append(landingprocess)
 
-    # This is the APRS-IS connection tap.  
+    # Start the aprsc sub process
+    logger.debug(f"Creating Aprsc subprocess")
+    aprscprocess = mp.Process(name="Aprsc", target=subprocesses.runSubprocess, args=(configuration, 'aprsc'))
+    aprscprocess.daemon = True
+    procs.append(aprscprocess)
+
+    # This is the APRS-IS connection tap, it will connect to the aprsc process we start above.
     logger.debug(f"Creating APRS-IS Tap subprocess")
     aprstap = mp.Process(name="APRS-IS Tap", target=connectors.connectorTap, args=(configuration, "aprs"))
     aprstap.daemon = True
@@ -401,14 +406,14 @@ def createProcesses(configuration):
 
     # if we're igating, then create a process to update a JSON file with igating statistics.  
     # Might expand on this idea in the future with a "stats" or "telemetry" process that publishes data about the backend.
-    igating = (True if configuration["igating"] == "true" else False) if "igating" in configuration else False
-    if igating:
+    #igating = (True if configuration["igating"] == "true" else False) if "igating" in configuration else False
+    #if igating:
 
         # The telemetry process
-        logger.debug(f"Creating Telemetry subprocess")
-        tmprocess = mp.Process(name="Telemetry", target=telemetry, args=(configuration,))
-        tmprocess.daemon = True
-        procs.append(tmprocess)
+    #    logger.debug(f"Creating Telemetry subprocess")
+    #    tmprocess = mp.Process(name="Telemetry", target=telemetry, args=(configuration,))
+    #    tmprocess.daemon = True
+    #    procs.append(tmprocess)
 
 
 
@@ -419,13 +424,6 @@ def createProcesses(configuration):
     #procs.append(rtp)
     ####### NO #######
 
-    # The aprsc process
-    # Don't need this process as the conectors will perform igating instead.
-    #
-    #logger.debug(f"Creating Aprsc subprocess")
-    #aprscprocess = mp.Process(name="Aprsc", target=subprocesses.runSubprocess, args=(configuration, 'aprsc'))
-    #aprscprocess.daemon = True
-    #procs.append(aprscprocess)
 
     # Return the list of newly created processes
     return procs
@@ -896,7 +894,8 @@ def main():
             configuration["igating"] = "false"
 
         # we want to connect to for aprs-is connectivity
-        configuration["aprsisserver"] = "noam.aprs2.net"
+        #configuration["aprsisserver"] = "noam.aprs2.net"
+        configuration["aprsisserver"] = "127.0.0.1"
 
         # where the direwolf instance is running
         configuration["direwolfserver"] = "127.0.0.1"

--- a/bin/kill_session.bash
+++ b/bin/kill_session.bash
@@ -47,7 +47,7 @@ if [ $? -eq 0 ]; then
     leadproc=$(ps -ef | grep "habtracker-daemon" | grep -v grep | awk 'BEGIN {s = 999999} { if ($2 < s) s=$2;} END {print s}')
     kill $leadproc >> ${LOGFILE}
 
-    # wait for 12 seconds looping each time to see if there are any remaining processes
+    # wait for some time looping each time to see if there are any remaining processes
     let num_procs=$(ps -ef | grep "habtracker-daemon" | grep -v grep | wc -l)
     let i=0
     while [ $num_procs -gt 0 ] && [ $i -lt 25 ]
@@ -73,7 +73,6 @@ if [ $? -eq 0 ]; then
         pkill -9 habtracker-daemon >> ${LOGFILE}
     fi
 fi
-exit
 
 # first kill aprsc because we have to use sudo...
 ps -ef | grep aprsc | grep -v grep > /dev/null

--- a/bin/procstatus.py
+++ b/bin/procstatus.py
@@ -32,7 +32,7 @@ listOfProcesses = list()
 
 habproc = "habtracker-d"
 
-procs = ["direwolf", "gpsd", habproc]
+procs = ["direwolf", "gpsd", habproc, "aprsc"]
 procstatus = []
 for p in procs:
     procstatus.append({"process": p, "status": 0})

--- a/bin/subprocesses.py
+++ b/bin/subprocesses.py
@@ -214,8 +214,8 @@ class SubProcess:
     def stop(self, process: int = None)->bool:
 
         # set the stop event so the run loop will terminate
-        #self.logger.debug(f"{self.name}: setting stop event")
-        #self.stopevent.set()
+        self.logger.info(f"{self.name}: setting stop event")
+        self.stopevent.set()
 
         # call _kill, just in case
         return self._kill()
@@ -237,7 +237,7 @@ class SubProcess:
         # Check if this sub-process is running
         if process.poll() is None:
 
-            self.logger.info(f"{self.name}: Terminating {self.name} sub-process, {process.pid}.")
+            self.logger.debug(f"{self.name}: Terminating {self.name} sub-process, {process.pid}.")
 
             # try to terminate it with a SIGTERM
             process.terminate()
@@ -245,7 +245,7 @@ class SubProcess:
             # now wait for the sub-process to end
             try:
 
-                self.logger.info(f"{self.name}: Waiting for {self.name} sub-process, {process.pid}, to end..")
+                self.logger.debug(f"{self.name}: Waiting for {self.name} sub-process, {process.pid}, to end..")
 
                 # wait a few seconds for the process to end
                 process.wait(6)
@@ -253,7 +253,7 @@ class SubProcess:
             except (sb.TimeoutExpired):
 
                 # sub-process didn't end so we now send a SIGKILL signal instead
-                self.logger.info(f"{self.name}: Killing {self.name} process {process.pid}...")
+                self.logger.debug(f"{self.name}: Killing {self.name} process {process.pid}...")
                 process.kill()
 
         # return the process state
@@ -319,16 +319,17 @@ class SubProcess:
                 self.logger.debug(f"{self.name}: starting process with command: {self.command}")
                 # the subprocess
                 self.p = sb.Popen(self.command, stdout=l, stderr=l)
-
                 self.logger.info(f"{self.name}: sub-process started pid: {self.p.pid}")
 
                 # Wait for the sub-process to finish
                 while self.p.poll() is None and not self.stopevent.is_set():
                     self.stopevent.wait(1)
 
+                self.logger.debug(f"{self.name}: process poll output: {self.p.poll()=}")
+
                 # Check if the sub-process is still running, if it is, then kill it
                 self._kill(self.p)
-                self.logger.info(f"{self.name}: sub-process, {self.p.pid}, ended")
+                self.logger.debug(f"{self.name}: sub-process, {self.p.pid}, ended.  stopevent: {self.stopevent.is_set()}")
 
                 # Close the log file
                 l.close()
@@ -337,13 +338,15 @@ class SubProcess:
                 if not restart:
                     break
         except (GracefulExit, KeyboardInterrupt, SystemExit) as e:
+            self._kill(self.p)
             self.logger.debug(f"{self.name}: caught keyboardinterrupt, {e}")
             self.stopevent.set()
             self.stop()
 
         finally:
             if self.p:
-                self.logger.info(f"{self.name}: sub-process has finished with retcode: {self.p.returncode}.")
+                self.logger.info(f"{self.name}: sub-process has finished")
+                self.logger.debug(f"{self.name}: sub-process has finished with retcode: {self.p.returncode}.")
 
         return self.p.returncode
 
@@ -598,65 +601,61 @@ class Direwolf(SubProcess):
                     f.write("###########################################\n\n")
 
 
+                self.logger.info(f"{self.name}: igating set to {self.igating}")
+                if self.igating:
 
-                    #### Only if we're igating... 
-                    #if self.igating == True:
+                    # when using aprsc (running locally) we need direwolf to always be configured to igate.  If a packet makes it to the APRS-IS cloud (or not) is determined 
+                    # by the "ro" or "full" flag within the aprsc configuration file for its uplink definition to noam.aprs2.net.
+                    self.logger.info(f"{self.name}: Direwolf configured to igate to 127.0.0.1 as {self.callsign}")
+                    password = self.configuration["passcode"]
+                    f.write("# APRS-IS Info\n")
+                    f.write("IGSERVER 127.0.0.1\n")
+                    f.write("IGLOGIN " + self.callsign + " " + str(password) + "\n\n")
 
-                        # when using aprsc (running locally) we need direwolf to always be configured to igate.  If a packet makes it to the APRS-IS cloud (or not) is determined by the "ro" or "full" flag
-                        # within the aprsc configuration file for its uplink definition to noam.aprs2.net.
-                        #
-                    #    self.logger.info(f"{self.name}: Direolf configured to igate to 127.0.0.1")
-                    #    password = self.configuration["passcode"]
-                    #    f.write("# APRS-IS Info\n")
-                    #    f.write("IGSERVER 127.0.0.1\n")
-                    #    f.write("IGLOGIN " + self.callsign + " " + str(password) + "\n\n")
+                    # If this station is beaconing directly to APRS-IS...then that can only happen if we have a IGSERVER defined (just above)...AND...aprsc is configured 
+                    # to have a "full" connection type on its uplink port definition to noam.aprs2.net.  That "full" flag is only set when igating is set to True, thus 
+                    # the "if self.igating" statement above.
+                    if self.configuration["ibeacon"] == "true":
 
-                        # If this station is beaconing directly to APRS-IS...then that can only happen if we have a IGSERVER defined (just above)...AND...aprsc is configured to have a "full" connection type on 
-                        # its uplink port definition to noam.aprs2.net.  That "full" flag is only set when igating is set to True, thus the "if self.igating" statement above.
-                    #    if self.configuration["ibeacon"] == "true":
+                        self.logger.info(f"{self.name}: Direwolf configured to use internet beaconing")
+                        f.write("########## for internet beaconing #########\n");
 
-                    #        self.logger.info(f"{self.name}: Direwolf configured to use internet beaconing")
+                        # If this is a mobile station, then we want to turn on "smart" beaconing.
+                        if self.configuration["mobilestation"] == "true":
+                            f.write("# This is for a mobile station\n")
+                            f.write("TBEACON sendto=IG  delay=0:40 every=" + str(self.configuration["ibeaconrate"]) + "  altitude=1  symbol=" + str(self.configuration["symbol"]) + overlay + "    comment=\"" + str(self.configuration["comment"]) +  "\"\n")
 
-                    #        f.write("########## for internet beaconing #########\n");
+                        # Otherwise, this is a fixed station so we just use the last alt/lat/lon as where this station is located at.
+                        else:
+                            # Only beacon our position if there is a valid GPS location
+                            if gpsposition["isvalid"]:
+                                f.write("# This is for a fixed station\n")
+                                f.write("PBEACON sendto=IG delay=0:40 every=11:00 altitude=" + str(gpsposition["altitude"]) + " lat=" + str(gpsposition["latitude"]) + " long=" + str(gpsposition["longitude"]) + " symbol=" + str(self.configuration["symbol"]) + overlay + " comment=\"" + str(self.configuration["comment"] + "\"\n"))
 
-                            # If this is a mobile station, then we want to turn on "smart" beaconing.
-                    #        if self.configuration["mobilestation"] == "true":
-                    #            f.write("# This is for a mobile station\n")
-                    #            f.write("TBEACON sendto=IG  delay=0:40 every=" + str(self.configuration["ibeaconrate"]) + "  altitude=1  symbol=" + str(self.configuration["symbol"]) + overlay + "    comment=\"" + str(self.configuration["comment"]) +  "\"\n")
+                        if self.igating == True:
+                            f.write("IBEACON sendto=IG  delay=0:50 every=" + str(self.configuration["ibeaconrate"]) + "\n")
 
-                            # Otherwise, this is a fixed station so we just use the last alt/lat/lon as where this station is located at.
-                    #        else:
-                                # Only beacon our position if there is a valid GPS location
-                    #            if gpsposition["isvalid"]:
-                    #                f.write("# This is for a fixed station\n")
-                    #                f.write("PBEACON sendto=IG delay=0:40 every=11:00 altitude=" + str(gpsposition["altitude"]) + " lat=" + str(gpsposition["latitude"]) + " long=" + str(gpsposition["longitude"]) + " symbol=" + str(self.configuration["symbol"]) + overlay + " comment=\"" + str(self.configuration["comment"] + "\"\n"))
+                        f.write("###########################################\n\n")
 
-                    #        if self.igating == True:
-                    #            f.write("IBEACON sendto=IG  delay=0:50 every=" + str(self.configuration["ibeaconrate"]) + "\n")
+                else:
+                    # we're not igating (to APRS-IS cloud), but direwolf still needs to upload packets to the local aprsc.
+                    # does it really?  I don't think we need direwolf to upload to aprsc for any eosstracker purposes because the 
+                    # local kisstap will get packets decoded by direwolf.  However, there might be external aprsc clients that will need a single consolidated stream.  
+                    #
+                    # When using aprsc (running locally) we need direwolf to always be configured to igate.  If a packet makes it to the APRS-IS cloud (or not) is determined 
+                    # by the "ro" or "full" flag within the aprsc configuration file for its uplink definition to noam.aprs2.net.
 
-                    #        f.write("###########################################\n\n")
+                    # However...when we're not configure to igate (i.e. aprsc has a 'ro' on its uplink port to noam.aprs2.net) we just use a random callsign for direwolf's
+                    # credentials to the locally running aprsc instance.  Presumably, because if we're not igating, then we can't trust the callsign + passcode from the user.
+                    basecallsign = self.callsign.split('-')[0]
+                    numRandomDigits = 9 - len(basecallsign)
+                    randomcallsign = basecallsign + str(random.randint(5, 10 ** numRandomDigits - 1)).zfill(numRandomDigits)
 
-                    #else:
-                        # we're not igating (to APRS-IS cloud), but direwolf still needs to upload packets to the local aprsc.
-                        # does it really?  I don't think we need direwolf to upload to aprsc for any eosstracker purposes because the local kisstap will get packets decoded by direwolf.  However, 
-                        # there might be external aprsc clients that will need a single consolidated stream.  
-                        #
-                        # commenting this out for now
-
-
-                        # when using aprsc (running locally) we need direwolf to always be configured to igate.  If a packet makes it to the APRS-IS cloud (or not) is determined by the "ro" or "full" flag
-                        # within the aprsc configuration file for its uplink definition to noam.aprs2.net.
-                        #
-                    #    basecallsign = self.callsign.split('-')[0]
-                    #    numRandomDigits = 9 - len(basecallsign)
-                    #    randomcallsign = basecallsign + str(random.randint(5, 10 ** numRandomDigits - 1)).zfill(numRandomDigits)
-
-                    #    self.logger.info(f"{self.name}: Direolf configured to igate to 127.0.0.1 as {randomcallsign}")
-                    #    password = aprslib.passcode(randomcallsign)
-                    #    f.write("# APRS-IS Info\n")
-                    #    f.write("IGSERVER 127.0.0.1\n")
-                    #    f.write("IGLOGIN " + randomcallsign + " " + str(password) + "\n\n")
-
+                    self.logger.info(f"{self.name}: Direwolf configured to igate to 127.0.0.1 as {randomcallsign}")
+                    password = aprslib.passcode(randomcallsign)
+                    f.write("# APRS-IS Info\n")
+                    f.write("IGSERVER 127.0.0.1\n")
+                    f.write("IGLOGIN " + randomcallsign + " " + str(password) + "\n\n")
 
                 # We're assuming that there's a GPS attached to this system
                 f.write("GPSD\n\n")
@@ -674,6 +673,414 @@ class Direwolf(SubProcess):
             self.logger.error(f"{self.name}: Unable to create direwolf configuration file: {error}")
             return False
                 
+
+
+
+
+##################################################
+# aprsc sub-process
+##################################################
+@dataclass
+class Aprsc(SubProcess):
+    """
+    This class will start the aprsc daemon.  There is an EOSS specific version of aprsc that allows for filters on the upstream connection that aprsc makes 
+    to noam.aprs2.net.  In order to determine if those filters are supported, it will first try and start aprsc with the "-y" switch to test the configuration, 
+    then if successful start the actual aprsc daemon.  If the "-y" test is not successful, then this class will proceed to start aprsc with the standard defintions
+    used on the upstream port to noam.aprsc.net.
+    """
+
+    #####################################
+    # the post init constructor
+    #####################################
+    def __post_init__(self)->None:
+        super().__post_init__()
+
+        # Name of this process 
+        self.setName('aprsc')
+
+        # the aprsc binary
+        self.aprsc_binary = "/opt/aprsc/sbin/aprsc"
+
+        # the output from the aprsc command (which shouldn't be anything)
+        self.setLogfile("/eosstracker/logs/aprsc.log")
+
+        # Default for the aprsc configuration file
+        if not self.config_file:
+            self.setConfig_file("/opt/aprsc/etc/tracker-aprsc.conf")
+
+        # Get just the filename without any path, but prefix that with "etc/"....because aprsc runs in a chroot environment (aka no absolute paths).
+        self.relative_config_file = "etc/" + os.path.basename(self.config_file)
+
+        # the name of the program we're going to run
+        if not self.binary:
+            self.setBinary("sudo")
+
+        # The default command string and arguments for running aprsc.
+        self.setArguments(args = [self.aprsc_binary, "-u", "aprsc", "-t", "/opt/aprsc", "-e", "info", "-o", "file", "-r", "logs", "-c" ])
+
+        # this is the randomized server ID that APRSC will use when connecting to the APRS-IS cloud its "username".
+        self.serverid = None
+        if self.callsign:
+            basecallsign = self.callsign.split('-')[0]
+            numRandomDigits = 9 - len(basecallsign)
+            randomcallsign = basecallsign + str(random.randint(5, 10 ** numRandomDigits - 1)).zfill(numRandomDigits)
+            self.serverid = randomcallsign
+        self.logger.info(f"{self.name}: APRS-IS serverid: {self.serverid}")
+        self.logger.debug(f"{self.name}: {self.configuration=}")
+
+
+        # check the APRS Radius we'll use (by default) as part of the filter we attempt to use for the APRSC's uplink connection to noam.aprs2.net
+        self.aprsradius = 400
+        if "aprsradius" in self.configuration:
+            if int(self.configuration["aprsradius"]) > 0:
+                self.aprsradius = int(self.configuration["aprsradius"])
+                self.logger.debug(f"{self.name}: APRS-IS radius: {self.aprsradius}km")
+
+        # APRS-IS Server
+        self.aprsserver = "noam.aprs2.net"
+
+        # custom filter (the user sets this from the Setup page)
+        self.customfilter = None
+        if "customfilter" in self.configuration:
+            self.customfilter = self.configuration["customfilter"]
+            self.logger.debug(f"{self.name} - custom APRS-IS filter: {self.customfilter}")
+
+        # by default we try to use a custom filter on the aprsc uplink configuration
+        self.usefilter = True
+
+        # set logging to DEBUG for this subprocess
+        #self.logger.setLevel(logging.DEBUG)
+
+
+    # we overload the command method to use the relative path to the configuration file for aprsc because it uses a chroot environment.
+    @property
+    def command(self)->str:
+        return [self.binary] + self.arguments + [self.relative_config_file]
+
+
+    ##################################################
+    # This creates the configuration file for aprsc
+    ##################################################
+    def createConfig(self)->bool:
+
+        # only if using a filter on the uplink APRS-IS upstream connection is desired.
+        if self.usefilter:
+
+            # construct an uplink filter string that will be used the the connection to noam.aprs2.net
+            uplinkfilter = self.getAPRSISFilter()
+
+            # prepend the 'filter ' string to our filter text
+            if len(uplinkfilter) > 0:
+                uplinkfilter = "filter " + uplinkfilter
+
+        try:
+
+            # Create or overwrite the aprsc configuration file.  We don't care if we overwrite it as the configuration is created dynamically each time.
+            with open(self.config_file, "w") as f:
+
+                # write some preamble to the file
+                f.write("###\n")
+                f.write("# " + self.config_file + "\n")
+                f.write("#\n\n\n")
+
+                f.write("ServerId " + self.serverid + "\n")
+                password = aprslib.passcode(str(self.serverid))
+                f.write("PassCode " + str(password) + "\n")
+
+                self.logger.debug(f"{self.name} Using username: {self.serverid}, password: {password}")
+
+                f.write("MyAdmin \"HAB Tracker\"\n")
+                f.write("MyEmail me@emailnotset.local\n")
+                f.write("RunDir data\n")
+                f.write("LogRotate 10 5\n")
+                f.write("UpstreamTimeout 5m\n")
+                f.write("ClientTimeout 48h\n")
+                f.write("Listen \"Full feed\"                                fullfeed tcp ::  10152 hidden\n")
+                f.write("Listen \"\"                                         fullfeed udp ::  10152 hidden\n")
+                f.write("Listen \"Client-Defined Filters\"                   igate tcp ::  14580\n")
+                f.write("Listen \"\"                                         igate udp ::  14580\n")
+
+                if self.igating:
+                    # For uploading packets received over RF (aka heard from gnuradio to Direwolf to aprsc), set this to "full" instead of "ro".
+                    if self.usefilter:
+                        f.write(f"Uplink \"Core rotate\" full  tcp  {self.aprsserver} 14580 {uplinkfilter}\n")
+                    else:
+                        f.write(f"Uplink \"Core rotate\" full  tcp  {self.aprsserver} 10152\n")
+                else:
+                    # This is set to be a read only connection to APRS-IS.  That is, we're not going to upload packets to any defined Uplink connections.
+                    if self.usefilter:
+                        f.write(f"Uplink \"Core rotate\" ro  tcp  {self.aprsserver} 14580 {uplinkfilter}\n")
+                    else:
+                        f.write(f"Uplink \"Core rotate\" ro  tcp  {self.aprsserver} 10152\n")
+
+                f.write("HTTPStatus 0.0.0.0 14501\n")
+                f.write("FileLimit        10000\n")
+
+                # close the file
+                f.close()
+
+            return True
+
+        except IOError as error:
+            self.logger.error(f"{self.name}: Unable to create aprsc configuration file, {self.config_file}: {error}")
+            return False
+                
+
+    ##################################################
+    # Create an APRS-IS filter string for the aprsc Uplink port.
+    # This filter is used to limit the amount of data downloaded from the
+    # APRS-IS servers.  
+    ##################################################
+    def getAPRSISFilter(self)->str:
+
+        # starting value for our APRS-IS filter string
+        aprsFilter = ""
+
+        # If the radius is <= 0 then we just return a blank filter string
+        if self.aprsradius <= 0:
+            return ""
+
+        # get our current location
+        gpsposition = self.getPosition()
+
+        # if we're unable to get GPS coordinates for then we a blank filter string
+        if gpsposition["isvalid"] == False:
+            self.logger.warning(f"{self.name}: Could not obtain station location.")
+            return ""
+
+        # Check the customfilter and prepend that to aprsFilter
+        if self.customfilter != None:
+            aprsFilter = self.customfilter
+
+        # construct the aprs radius filter string
+        aprsFilter = aprsFilter + " r/" + str(gpsposition["latitude"]) + "/" + str(gpsposition["longitude"]) + "/" + str(self.aprsradius)
+
+
+        # connect to the database to get a list of flights and their beacons.  If successful, append the aprsFilter string with additional 
+        # elements for the beacon callsigns (ex. friend filters and radius ftilers).
+        try:
+
+            # Database connection
+            pgConnection = pg.connect(habconfig.dbConnectionString)
+            #pgCursor = pgConnection.cursor()
+
+            # get a list of active flights
+            # columns for returned numpy array:  flightid, callsign, launchsite name, launchsite lat, launch lon, launchsite elevation
+            flights = queries.getFlights(pgConnection, self.logger)
+
+            # Loop through each beacon callsign, building the APRS-IS filter string
+            beaconFilter = ""
+            for beacon in flights:
+                beaconFilter = beaconFilter + "/" + beacon[1]
+
+            # Append the beacon filter to our running filter string
+            aprsFilter = aprsFilter + (" b" + beaconFilter if len(beaconFilter) > 0 else "")
+
+            # Loop through the first 9 beacons adding 100km friend filters for each one. 
+            friendFilter = ""
+            for beacon in flights[0:9]:
+                friendFilter = friendFilter + " f/" + beacon[1] + "/100"
+
+            # Append the friend filter to our running filter string
+            aprsFilter = aprsFilter + (friendFilter if len(friendFilter) > 0 else "")
+
+            # Close database connection
+            pgConnection.close()
+
+            self.logger.info(f"{self.name} Using this filter for APRS-IS uplink: {aprsFilter}")
+
+
+        except pg.DatabaseError as error:
+            pgCursor.close()
+            pgConnection.close()
+            self.logger.error(f"{self.name} Database error: {error}")
+
+        except (StopIteration, KeyboardInterrupt, SystemExit):
+            pgCursor.close()
+            pgConnection.close()
+
+        finally:
+
+            # Return the resulting APRS-IS filter string
+            return aprsFilter
+
+
+
+    ##################################################
+    # test if aprsc will support a custom filter string on its uplink connection.
+    ##################################################
+    def testConfigFile(self)->bool:
+
+        # if we've already determined that aprsc doesn't support a custom filter on its APRS-IS uplink port, then just return
+        if not self.usefilter:
+            return self.usefilter
+
+        ##########
+        # We build the configuration file assuming we're running the modified aprsc binary that accepts filter commands on the Uplink port.
+        # To check, we run with the "-y" switch and examine the return code.  If > 0, then aprsc is reporting a syntax error with the configuration file,
+        # presumably because of our additional filter string on the uplink port definition.  Therefore for return codes > 0, we can't use the custom
+        # filter syntax on the uplink port definition within the aprsc config file.
+        #
+        # Example (with custom filter):
+        #    Uplink "Core rotate" full  tcp  noam.aprs2.net 14580 filter r/39/-103/200
+        #
+        # Example (without custom filter):
+        #    Uplink "Core rotate" full  tcp  noam.aprs2.net 10152
+        #
+        #
+        ##########
+
+        # Create the configuration file with this custom filter.
+        # If we can't create the configuration file, then we have to exit...
+        if not self.createConfig():
+            return False
+
+        # For reference we must run aprsc as root (thus the need for sudo) so that it can chroot to the /opt/aprsc path.
+        # For example:
+        #     sudo /opt/aprsc/sbin/aprsc -u aprsc -t /opt/aprsc -e info -o file -r logs -c etc/aprsc-tracker.conf
+
+        # We first run aprsc with the "-y" switch to test the configuration file for syntax.
+        newargs = self.arguments.copy()
+        newargs.insert(len(newargs)-1, "-y")
+        aprsc_syntax_command = [self.binary] + newargs + [self.relative_config_file]
+
+        try:
+            # Run the aprsc command, but we redirect output to /dev/null because we only care about the return code
+            devnull = open(os.devnull, "w")
+            p = sb.Popen(aprsc_syntax_command, stdout=devnull, stderr=sb.STDOUT)
+
+            # Wait for it to finish and grab the return code.
+            r = p.wait()
+
+            # Make sure devnull is closed
+            devnull.close()
+
+            # If the return code is zero, then we can continue on using the custom filter on the Uplink connection.  If not zero, then
+            # there was an error with the aprsc configuration file syntax, presumably because of our custom filter on the uplink port.
+            if r != 0:
+                self.usefilter = False
+                self.logger.warning(f"{self.name}:  aprsc does not support custom uplink filters, trying without.")
+
+            # The aprsc process should NOT be running, but if it is, we need to kill it.
+            if p.poll() is None:
+                
+                # signal our process to terminate
+                p.terminate()
+
+                # Issue the "sudo pkill aprsc" command to the backend
+                self._pkill()
+
+                try:
+                    # wait on the process to end
+                    p.wait(6)
+                    self.logger.warning(f"{self.name}: aprsc test config process ended")
+
+                except (sb.TimeoutExpired):
+
+                    # Now terminate our process since it must be hung 
+                    p.kill()
+
+        except (GracefulExit, KeyboardInterrupt, SystemExit):
+            if p.poll() is None:
+
+                # signal our process to terminate
+                p.terminate()
+
+                # Issue the "sudo pkill aprsc" command to the backend
+                self._pkill()
+
+                try:
+                    # wait on the process to end
+                    p.wait(6)
+                    self.logger.warning(f"{self.name}: aprsc test config process ended")
+
+                except (sb.TimeoutExpired):
+
+                    # Now terminate our process since it must be hung 
+                    p.kill()
+
+        return self.usefilter
+
+
+
+    ##################################################
+    # run the aprsc daemon
+    ##################################################
+    def run(self)->int:
+
+        # test if aprsc will support a custom filter on the APRS-IS uplink connection
+        result = self.testConfigFile()
+        self.logger.info(f"{self.name}: {'not' if not result else ''} using custom filter on APRS-IS uplink connection")
+
+        return super().run()
+
+
+
+    ##################################################
+    # Issue the "sudo pkill aprsc" command
+    ##################################################
+    def _pkill(self)->bool:
+
+        # the command we want to execute
+        killem = ["sudo", "pkill", "aprsc"]
+
+        # Execute the "pkill" command
+        self.logger.debug(f"{self.name}: using 'pkill' to signal all aprsc processes to end")
+        sb.Popen(killem)
+
+
+
+    ##################################################
+    # kill the sub-process
+    ##################################################
+    def _kill(self, process: int = None)->bool:
+
+        # we need to override the _kill method so we can issue a "sudo pkill aprsc" command.  Otherwise we end up with the aprsc
+        # process still running as it switches users at startup as part of chroot'ing to a less priviledged running environment.
+        # 
+        # Obviously for this to work the user running this backend python needs to be setup within the /etc/sudoers file as having
+        # permissions to execute "sudo pkill aprsc" without being prompted for a password.
+        #
+
+        # sanity check
+        if process is None and self.p is None:
+            return False
+
+        # if we were called without a pid, the use our own
+        if process is None:
+            process = self.p
+        
+        # Check if this sub-process is running
+        if process.poll() is None:
+
+            self.logger.debug(f"{self.name}: Terminating {self.name} sub-process, {process.pid}.")
+
+            # Signal our process to terminate as well (if it wasn't already killed by the "pkill" command)
+            process.terminate()
+
+            # Issue the "sudo pkill aprsc" command to the backend
+            self._pkill()
+
+            # now wait for the sub-process to end
+            try:
+
+                self.logger.debug(f"{self.name}: Waiting for {self.name} sub-process, {process.pid}, to end..")
+
+                # wait a few seconds for the process to end
+                process.wait(6)
+
+            except (sb.TimeoutExpired):
+
+                # sub-process didn't end so we now send a SIGKILL signal instead
+                self.logger.debug(f"{self.name}: Killing {self.name} process {process.pid}...")
+                process.kill()
+
+                # Issue the "sudo pkill aprsc" command to the backend
+                self._pkill()
+
+        # return the process state
+        return process.poll()
+
 
 
 ##################################################
@@ -703,6 +1110,8 @@ def runSubprocess(config: list = None, subtype: str = None):
         logger.info(f"Starting {subtype}")
         if subtype == "direwolf":
             k = Direwolf(configuration = config)
+        elif subtype == "aprsc":
+            k = Aprsc(configuration = config)
         else:
             logger.error("Sub-process type, {subtype}, not supported")
             return
@@ -714,8 +1123,8 @@ def runSubprocess(config: list = None, subtype: str = None):
         k.run()
 
     except (KeyboardInterrupt, SystemExit, GracefulExit) as e: 
+        logger.info("caught keyboard interrupt")
         k.stop()
 
     finally:
         logger.info(f"{subtype} ended.")
-

--- a/www/common/index.js
+++ b/www/common/index.js
@@ -74,7 +74,7 @@ function getConfiguration() {
         document.getElementById("timezone").innerHTML = timezone;
         document.getElementById("igating").innerHTML = i2;
         document.getElementById("beaconing").innerHTML = b2;
-        document.getElementById("ssid").innerHTML = ssid; 
+        document.getElementById("ssid").innerHTML = (ssid != "" ? "-" + ssid : ""); 
     });
 }
 

--- a/www/index.php
+++ b/www/index.php
@@ -89,6 +89,10 @@ include $documentroot . '/common/header.php';
             <div class="table-cell" style="text-align: right;"><span id="gpsd-status"><mark class="notokay">Not okay</mark></span></div>
         </div>
         <div class="table-row">
+            <div class="table-cell">aprsc</div>
+            <div class="table-cell" style="text-align: right;"><span id="aprsc-status"><mark class="notokay">Not okay</mark></span></div>
+        </div>
+        <div class="table-row">
             <div class="table-cell">backend daemon</div>
             <div class="table-cell" style="text-align: right;"><span id="habtracker-d-status"><mark class="notokay">Not okay</mark></span></div>
         </div>


### PR DESCRIPTION
Drops the use of internal igating features in favor of starting the aprsc subprocess to handle such things.  Includes changes to Direwolf’s configuration file to redirect it to igate to the locally running aprsc instance and updates to the index.php/index.js files to handle checking for the aprsc process.  The internal igating function was using a multi-process queue to handle packets and it seemed that was prone to filling up (not that such things weren’t handled properly) - leaving all of that headache to aprsc seemed a better more efficient solution.  It also has the benefit of being tried and true as all prior revisions leverage that process.