### PR TITLE
Add the ability to reference an off-host instance of GPSD

### DIFF
--- a/bin/subprocesses.py
+++ b/bin/subprocesses.py
@@ -661,7 +661,11 @@ class Direwolf(SubProcess):
                     f.write("IGLOGIN " + randomcallsign + " " + str(password) + "\n\n")
 
                 # We're assuming that there's a GPS attached to this system
-                f.write("GPSD\n\n")
+                if "gpshost" in self.configuration:
+                    if self.configuration["gpshost"] == "localhost" or self.configuration["gpshost"] == "local" or self.configuration["gpshost"] == "":
+                        f.write("GPSD\n\n")
+                    else:
+                        f.write(f"GPSD {self.configuration['gpshost']}\n\n")
 
                 # The rest of the direwolf configuration
                 f.write("AGWPORT 8000\n")

--- a/www/common/index.js
+++ b/www/common/index.js
@@ -145,6 +145,10 @@ function getrecentdata() {
           //document.getElementById("debug").innerHTML = "starting up still...processInTransition: " + processInTransition;
           if (procs >= keys.length - 1)
               processInTransition = 0;
+
+          else if (procs <= 1 && statusJson.active == 0)
+              // we must have tried to start, but hit a failure and now nothing is running.
+              processInTransition = 0;
           $("#direwolferror").html("");
           return;
       }
@@ -277,6 +281,7 @@ function getgps() {
         theDate = theDate.replace(/T/g, " "); 
         theDate = theDate.replace(/.[0-9]*Z$/g, ""); 
         var gpshtml = "<table cellpadding=0 cellspacing=0 border=0>" 
+            + "<tr><td style=\"text-align: left; padding-right: 10px;\">Host:</td><td><strong>" + jsonData.host + "</strong></td></tr>"
             + "<tr><td style=\"text-align: left; padding-right: 10px;\">UTC Time:</td><td>" + theDate + "</td></tr>"
             + "<tr><td style=\"text-align: left; padding-right: 10px;\">Latitude:</td><td>" + jsonData.lat + "</td></tr>"
             + "<tr><td style=\"text-align: left; padding-right: 10px;\">Longitude:</td><td>" + jsonData.lon + "</td></tr>"

--- a/www/configuration/defaults.txt
+++ b/www/configuration/defaults.txt
@@ -10,6 +10,7 @@
     "fastrate": "01:00",
     "fastspeed": "45",
     "fastturn": "20",
+    "gpshost": "",
     "ibeacon": "false",
     "ibeaconrate": "15:00",
     "iconsize": "24",

--- a/www/setconfiguration.php
+++ b/www/setconfiguration.php
@@ -59,6 +59,7 @@
     $ray["ibeacon"] = "false";
     $ray["airdensity"] = "false";
     $ray["mobilestation"] = "true";
+    $ray["gpshost"] = "";
     $fallbackJSON = json_encode($ray);
 
 

--- a/www/setup.php
+++ b/www/setup.php
@@ -521,39 +521,19 @@ include $documentroot . '/common/header.php';
             <div id="configurationSelection" style="display: none;">
             <p class="normal-italic">
                 Use this section to set configuration parameters for the HAB Tracker system.  These settings are system-wide and are not configurable on a per user basis.
-            </p>
-            <p class="header" style="font-size: 1.2em;"> 
-                <img class="bluesquare" style="width: 8px; margin: 0px; padding: 7px; padding-right: 15px;"  src="/images/graphics/smallbluesquare.png">
-                Timezone
-            <p ><span id="settimezone_error"></span></p>
-            <p>
-                Changes to the timezone take effect immediately across all web screens, but do not impact the local computer system time.  The timezone setting is persistent across process restarts and computer reboots/power-cycles.
-                <form name="timezone_form" id="timezone_form">
-                <table class="packetlist" style="margin-left: 30px; margin-right: 30px; margin-top: 10px; width: auto;" cellpadding=0 cellspacing=0 border=0>
-		<tr><th class="packetlistheader">Configuration Item</th><th class="packetlistheader" style="text-align: center;">Value</th></tr>
-                <tr><td class="packetlist"><strong>Timezone</strong> used throughout the interface.</td>
-		    <td class="packetlist" style="white-space: nowrap; padding: 5px;">Timezone: <select form="timezone_form" id="settimezone" onchange="setTimeZone(this);"></select></td>
-                </tr>
-                </table>
-                </form>
-            </p>
-
-            <p class="header" style="font-size: 1.2em;"> 
-                <img class="bluesquare" style="width: 8px; margin: 0px; padding: 7px; padding-right: 15px;"  src="/images/graphics/smallbluesquare.png">
-                Transmitting and Igating 
-            </p>
-	    <p >
             These values are <font style="text-decoration: underline;">OPTIONAL</font> and not required for regular, read-only/receive-only operation.  A valid ham radio callsign is mandatory    if igating (ex. uploading of APRS packets to the Internet) or beaconing via APRS is desired (i.e. transmitting APRS packets over radio frequencies).
-            </p>
-	    <p >
-                Changes to settings require the system processes to be restarted (on the <a href="/" class="normal-link-black">Home page</a>) before taking effect.  Settings are persistent across process restarts and computer reboots/power-cycles.
+            Changes to settings require the system processes to be restarted (on the <a href="/" class="normal-link-black">Home page</a>) before taking effect.  Settings are persistent across process restarts and computer reboots/power-cycles.
             </p>
             <p><span id="configurationsettings_error"></span></p>
             <p style="margin-top: 20px; margin-bottom: 10px;">
                 <form name="configuration_form" id="configuration_form">
                 <table class="packetlist" style="margin-left: 30px; margin-right: 30px; width: 80%;" cellpadding=0 cellspacing=0 border=0>
 		<tr><th colspan=2 class="packetlistheader">Configuration Item</th><th class="packetlistheader" style="text-align: center;">Value</th></tr>
-		<tr><td colspan=2 class="packetlist"><strong>Callsign and SSID</strong>.  Enter your ham radio callsign and select an appropriate SSID.</td>
+        <tr><td class="packetlist-highlight2"  rowspan=1 style="padding-top: 20px; padding-bottom: 20px;">
+                <div style="-webkit-transform: rotate(270deg);  -ms-transform: rotate(270deg); transform: rotate(270deg); font-variant: small-caps; vertical-align: middle; text-align: center;">Identity</div>
+            </td>
+
+            <td class="packetlist"><strong>Callsign and SSID</strong>.  Enter your ham radio callsign and select an appropriate SSID.</td>
 		    <td class="packetlist" style="text-align: center; white-space: nowrap;">Callsign: <input type="text" form="configuration_form" id="callsign" oninput="setCustomValidity('');" onchange="validateCallsign();" placeholder="callsign" style="text-transform: uppercase;"  pattern="[a-zA-Z]{1,2}[0-9]{1}[a-zA-Z]{1,3}" size="9" maxlength="6" name="callsign" autocomplete="off" autocapitalize="off" spellcheck="false" autocorrect="off" >
                     &nbsp; SSID: 
                     <select id="ssid" name="ssid" form="configuration_form" onchange="validateCallsign();">
@@ -578,6 +558,38 @@ include $documentroot . '/common/header.php';
                 </tr> 
 
 
+		<tr><td colspan=3 class="packetlist-highlight" style="font-size: 1.1em; font-variant: small-caps; ">Timezone</td></tr>
+        <tr> <td class="packetlist-highlight2"  rowspan=1 style="padding-top: 20px; padding-bottom: 20px;">
+                 <div style="-webkit-transform: rotate(270deg);  -ms-transform: rotate(270deg); transform: rotate(270deg); font-variant: small-caps; vertical-align: middle; text-align: center;">Timezone</div>
+             </td>
+
+             <td class="packetlist">
+                 <strong>Timezone</strong> used throughout the interface.  Changes to the timezone take effect immediately across all web screens, but do not impact the local computer system time.  This timezone setting is persistent across process restarts and computer reboots/power-cycles.
+             </td>
+
+             <td class="packetlist"  style="text-align: right;">Timezone: 
+                 <select form="configuration_form" id="settimezone"></select>
+             </td>
+        </tr> 
+
+
+		<tr><td colspan=3 class="packetlist-highlight" style="font-size: 1.1em; font-variant: small-caps; ">Global Positioning System (GPS)</td></tr>
+        <tr> <td class="packetlist-highlight2"  rowspan=1 style="padding-top: 20px; padding-bottom: 20px;">
+                 <div style="-webkit-transform: rotate(270deg);  -ms-transform: rotate(270deg); transform: rotate(270deg); font-variant: small-caps; vertical-align: middle; text-align: center;">GPS</div>
+             </td>
+
+             <td class="packetlist">
+                 <strong>GPS</strong> is used to determine the location and altitude of this system.  For a locally attached GPS device (ex. serial or USB connection) leave this blank or "localhost".  To 
+                     leverage the GPS connected to another system enter the IP address or hostname of that system here.  This assumes the "other" system is running GPSD and is accessible on the same
+                     network as this system.
+             </td>
+
+             <td class="packetlist"  style="text-align: right;">GPSD Host: 
+                 <input form="configuration_form" id="gpshost" style="text-align: center;" size="16" maxlength="64" name="gpshost" autocomplete="off" autocapitalize="off" spellcheck="false" autocorrect="off" placeholder="localhost">
+             </td>
+        </tr> 
+
+
 		<tr><td colspan=3 class="packetlist-highlight" style="font-size: 1.1em; font-variant: small-caps; ">APRS-IS Internet Uplink</td></tr>
         <tr> <td class="packetlist-highlight2"  rowspan=1>
              <div style="-webkit-transform: rotate(270deg);  -ms-transform: rotate(270deg); transform: rotate(270deg); font-variant: small-caps; vertical-align: middle; text-align: center;">APRS-IS</div></td>
@@ -588,6 +600,7 @@ include $documentroot . '/common/header.php';
                     Radius (km): <input type="number"  form="configuration_form" style="text-align: right;" size="6" name="filter_radius" id="filter_radius" autocomplete="off" autocapitalize="off" spellcheck="false" autocorrect="off"  placeholder="radius" max="5000" min="100" step="50">
              </td>
         </tr> 
+
 
 		<tr><td colspan=3 class="packetlist-highlight" style="font-size: 1.1em; font-variant: small-caps; ">Igating to the Internet</td></tr>
 		<tr>


### PR DESCRIPTION
Adds a field under the Setup screen where one can enter the hostname or IP address of a network accessible host that’s running GPSD.  The system will then use that hostname for connecting to that instance of GPSD foregoing the search for a locally attached GPS [puck].  

For use in those instances where a centralized computer (raspberry pi?) is connected to a physical GPS (usb or serial) and then serves all GPSD clients over the network.