### PR TITLE
Add abilty to listen to a ka9q-radio source on the local network

### DIFF
--- a/www/common/index.js
+++ b/www/common/index.js
@@ -63,6 +63,8 @@ function getConfiguration() {
         var b = (beaconing == "true" ? "yes" : "no");
         var b2 = (b == "yes" ? "<mark class=\"marginal\">" + b + (eoss != "" ? "</mark><br>Path String: <mark class=\"marginal\">" + eoss + " " : "") + "</mark>" : b);
         var ssid = jsonData.ssid;
+        var ka9q = (typeof(jsonData.ka9qradio) == "undefined" ? false : (jsonData.ka9qradio == "true" ? true : false));
+        var ka9qhtml = (ka9q ? "<mark class=\"marginal\">yes</mark>" : "no");
 
         // check if we should even be using an ssid (i.e. we're not beaconing) or if it's '0' and we shouldn't be displaying it with a callsign
         if (typeof(jsonData.beaconing) == "undefined" || callsign == "" || ssid == "0" || ssid == 0)
@@ -75,6 +77,7 @@ function getConfiguration() {
         document.getElementById("igating").innerHTML = i2;
         document.getElementById("beaconing").innerHTML = b2;
         document.getElementById("ssid").innerHTML = (ssid != "" ? "-" + ssid : ""); 
+        document.getElementById("ka9qradio").innerHTML = ka9qhtml;
     });
 }
 
@@ -145,6 +148,9 @@ function getrecentdata() {
 
       // is the backend connected to an SDR dongle?
       var isRFMode = (typeof(statusJson.rf_mode) != "undefined" ? (statusJson.rf_mode == 1 || statusJson.rf_mode == "true" || statusJson.rf_mode == true ? true : false) : false);
+
+      // are we listening for packets from an instance of KA9Q-Radio running on the local network?
+      var isKa9qradio = (typeof(statusJson.ka9qradio) != "undefined" ? (statusJson.ka9qradio == 1 || statusJson.ka9qradio == "true" || statusJson.ka9qradio == true ? true : false) : false);
 
       // should we be expecting gpsd to be running?  Is the gpshost set to the local system?
       var gpsHost = (typeof(statusJson.gpshost) != "undefined" ? statusJson.gpshost.toLowerCase() : "");
@@ -327,10 +333,13 @@ function getrecentdata() {
               }
           }
           else if (isRunning && !isRFMode) {  // We're running in online mode...i.e. SDRs are not attached to the system
+              if (isKa9qradio) 
+                  donehtml = "<p><mark class=\"okay\">Listening for packets from KA9Q-Radio</mark></p>";
+              else
                   donehtml = "<p><mark class=\"okay\">Running in online mode - no SDRs found.</mark></p>";
 
-                  // Update the onscreen status
-                  $("#antenna-data").html(donehtml);
+              // Update the onscreen status
+              $("#antenna-data").html(donehtml);
           }
           else {  // we're not running
               var donehtml = "<p><mark class=\"marginal\">Not running.</mark></p>";

--- a/www/common/setup.js
+++ b/www/common/setup.js
@@ -1496,6 +1496,7 @@
             document.getElementById("slowturn").value = (typeof(jsonData.slowturn) == "undefined" ? "" : jsonData.slowturn);	    
             document.getElementById("includeeoss").checked = (typeof(jsonData.includeeoss) == "undefined" ? false : (jsonData.includeeoss == "true" ? true : false));
             document.getElementById("mobilestation").checked = (typeof(jsonData.mobilestation) == "undefined" ? false : (jsonData.mobilestation == "true" ? true : false));
+            document.getElementById("ka9qradio").checked = (typeof(jsonData.ka9qradio) == "undefined" ? false : (jsonData.ka9qradio == "true" ? true : false));
             document.getElementById("eoss_string").value = (typeof(jsonData.eoss_string) == "undefined" ? "EOSS" : jsonData.eoss_string);
             document.getElementById("comment").value = (typeof(jsonData.comment) == "undefined" ? "EOSS Tracker" : jsonData.comment);
             document.getElementById("gpshost").value = (typeof(jsonData.gpshost) == "undefined" ? "" : jsonData.gpshost);	    
@@ -1670,6 +1671,7 @@
         var filter_radius = document.getElementById("filter_radius");
 	    var gpshost = document.getElementById("gpshost");
         var timezone = document.getElementById("settimezone");
+        var ka9qradio = document.getElementById("ka9qradio");
 
 	    var fields = [ comment, fastspeed, fastrate, slowspeed, slowrate, beaconlimit, fastturn, slowturn ];
 	    var f;
@@ -1725,6 +1727,7 @@
 		    form_data.append("passcode", "");
         }
 
+        form_data.append("ka9qradio", ka9qradio.checked.toString());
         form_data.append("mobilestation", mobilestation.checked.toString());
 
 	    if (beaconing.checked) {

--- a/www/configuration/defaults.txt
+++ b/www/configuration/defaults.txt
@@ -16,6 +16,7 @@
     "iconsize": "24",
     "igating": "false",
     "includeeoss": "true",
+    "ka9qradio": "false",
     "lookbackperiod": "180",
     "objectbeaconing": "false",
     "overlay": "",

--- a/www/getactiveflights.php
+++ b/www/getactiveflights.php
@@ -522,7 +522,7 @@
                         z.lon,
                         z.sourcename,
                         case when array_length(z.path, 1) > 0 then
-                            z.path[array_length(z.path, 1)]
+                            split_part(z.path[array_length(z.path, 1)], '*',1)
                         else
                             z.sourcename
                         end as heardfrom,

--- a/www/getaudioalerts.php
+++ b/www/getaudioalerts.php
@@ -296,7 +296,7 @@
                         extract ('epoch' from (now()::timestamp - c.thetime)) as elapsed_secs,
                         c.sourcename,
                         case when array_length(c.path, 1) > 0 then
-                            c.path[array_length(c.path, 1)]
+                            split_part(c.path[array_length(c.path, 1)], '*', 1)
                         else
                             c.sourcename
                         end as heardfrom,

--- a/www/getdashboardpackets.php
+++ b/www/getdashboardpackets.php
@@ -249,7 +249,7 @@
                         c.raw,
                         c.sourcename,
                         case when array_length(c.path, 1) > 0 then
-                            c.path[array_length(c.path, 1)]
+                            split_part(c.path[array_length(c.path, 1)], '*', 1)
                         else
                             c.sourcename
                         end as heardfrom,

--- a/www/getflightdata.php
+++ b/www/getflightdata.php
@@ -459,7 +459,7 @@
                         extract ('epoch' from (now()::timestamp - c.thetime)) as elapsed_secs,
                         c.sourcename,
                         case when array_length(c.path, 1) > 0 then
-                            c.path[array_length(c.path, 1)]
+                            split_part(c.path[array_length(c.path, 1)],'*',1)
                         else
                             c.sourcename
                         end as heardfrom,
@@ -770,7 +770,7 @@
             y.freq,
             y.channel,
             case when array_length(y.path, 1) > 0 then
-                y.path[array_length(y.path, 1)]
+                split_part(y.path[array_length(y.path, 1)],'*',1)
             else
                 y.sourcename
             end as heardfrom,

--- a/www/getflightpackets.php
+++ b/www/getflightpackets.php
@@ -275,7 +275,7 @@
                         z.lon,
                         z.sourcename,
                         case when array_length(z.path, 1) > 0 then
-                            z.path[array_length(z.path, 1)]
+                            split_part(z.path[array_length(z.path, 1)], '*', 1)
                         else
                             z.sourcename
                         end as heardfrom,

--- a/www/getotherdata.php
+++ b/www/getotherdata.php
@@ -75,7 +75,7 @@
             f.callsign,
             f.sourcename,
             case when array_length(f.path, 1) > 0 then
-                f.path[array_length(f.path, 1)]
+                split_part(f.path[array_length(f.path, 1)],'*',1)
             else
                 f.sourcename
             end as heardfrom,
@@ -290,7 +290,7 @@
         z.freq,
         z.channel,
         case when array_length(z.path, 1) > 0 then
-            z.path[array_length(z.path, 1)]
+            split_part(z.path[array_length(z.path, 1)], '*', 1)
         else
             z.sourcename
         end as heardfrom,
@@ -679,7 +679,7 @@
             y.freq,
             y.channel,
             case when array_length(y.path, 1) > 0 then
-                y.path[array_length(y.path, 1)]
+                split_part(y.path[array_length(y.path, 1)], '*', 1)
             else
                 y.sourcename
             end as heardfrom,

--- a/www/getrfstations.php
+++ b/www/getrfstations.php
@@ -76,7 +76,7 @@
             f.callsign,
             f.sourcename,
             case when array_length(f.path, 1) > 0 then
-                f.path[array_length(f.path, 1)]
+                split_part(f.path[array_length(f.path, 1)], '*', 1)
             else
                 f.sourcename
             end as heardfrom,

--- a/www/gettrackercountstable.php
+++ b/www/gettrackercountstable.php
@@ -86,7 +86,7 @@
             a.tm,
             a.callsign,
             case when array_length(a.path, 1) > 0 then
-                a.path[array_length(a.path, 1)]
+                split_part(a.path[array_length(a.path, 1)], '*', 1)
             else
                 a.sourcename
             end as heardfrom,

--- a/www/gettrackerstations.php
+++ b/www/gettrackerstations.php
@@ -96,7 +96,7 @@
             y.freq,
             y.channel,
             case when array_length(y.path, 1) > 0 then
-                y.path[array_length(y.path, 1)]
+                split_part(y.path[array_length(y.path, 1)], '*', 1)
             else
                 y.sourcename
             end as heardfrom,

--- a/www/index.php
+++ b/www/index.php
@@ -126,8 +126,12 @@ include $documentroot . '/common/header.php';
             <div class="table-cell" style="text-align: right; border-left: none; border-top: none;"><span id="igating"></span></div>
         </div>
         <div class="table-row">
-            <div class="table-cell" style="border-top: none;">Beaconing:</div>
+            <div class="table-cell" style="border-top: none;">RF Beaconing:</div>
             <div class="table-cell" style="text-align: right; border-left: none; border-top: none;"><span id="beaconing"></span></div>
+        </div>
+        <div class="table-row">
+            <div class="table-cell" style="border-top: none;">Listening for KA9Q-Radio:</div>
+            <div class="table-cell" style="text-align: right; border-left: none; border-top: none;"><span id="ka9qradio"></span></div>
         </div>
     </div>
 

--- a/www/readconfiguration.php
+++ b/www/readconfiguration.php
@@ -59,6 +59,8 @@
     $ray["ibeacon"] = "false";
     $ray["airdensity"] = "false";
     $ray["mobilestation"] = "true";
+    $ray["gpshost"] = "";
+    $ray["ka9qradio"] = "false";
     $fallbackJSON = json_encode($ray);
 
     // Defaults

--- a/www/setconfiguration.php
+++ b/www/setconfiguration.php
@@ -60,6 +60,7 @@
     $ray["airdensity"] = "false";
     $ray["mobilestation"] = "true";
     $ray["gpshost"] = "";
+    $ray["ka9qradio"] = "false";
     $fallbackJSON = json_encode($ray);
 
 

--- a/www/setup.php
+++ b/www/setup.php
@@ -590,6 +590,20 @@ include $documentroot . '/common/header.php';
         </tr> 
 
 
+		<tr><td colspan=3 class="packetlist-highlight" style="font-size: 1.1em; font-variant: small-caps; ">KA9Q-Radio</td></tr>
+        <tr> <td class="packetlist-highlight2"  rowspan=1 style="padding-top: 20px; padding-bottom: 20px;">
+                 <div style="-webkit-transform: rotate(270deg);  -ms-transform: rotate(270deg); transform: rotate(270deg); font-variant: small-caps; vertical-align: middle; text-align: center;">KA9Q-Radio</div>
+             </td>
+
+             <td class="packetlist">
+                 <strong>KA9Q-Radio</strong> uses a novel approach in distributing audio streams from radio frequencies.  If this option is enabled, this system will listen for any audio streams produced
+                     by a KA9Q-Radio instance running on the local network.  
+             </td>
+             <td class="packetlist"  id="ka9qradiotext" style="text-align: center; white-space: nowrap;">Listen for KA9Q-Radio: <input type="checkbox" form="configuration_form" name="ka9qradio" id="ka9qradio"></td>
+        </tr> 
+
+
+
 		<tr><td colspan=3 class="packetlist-highlight" style="font-size: 1.1em; font-variant: small-caps; ">APRS-IS Internet Uplink</td></tr>
         <tr> <td class="packetlist-highlight2"  rowspan=1>
              <div style="-webkit-transform: rotate(270deg);  -ms-transform: rotate(270deg); transform: rotate(270deg); font-variant: small-caps; vertical-align: middle; text-align: center;">APRS-IS</div></td>


### PR DESCRIPTION
Add feature so under the Setup screen, the user can select to have the system listen to a KA9Q-Radio source.  Once selected and the processes restarted, the system will attempt to connect to the multicast group address and add any heard packets to the local postgresql database.  This assumes of course, that there is another system (RPi perhaps) running the ka9q-radio on the local network (i.e. the same network that this system is resident on).  