### PR TITLE
Get better status messaging back from git pulls when a user hits the Synchronize button

### DIFF
--- a/www/common/setup.js
+++ b/www/common/setup.js
@@ -791,7 +791,17 @@
     ***********/
     function gitPullFiles() {
         $.get("gitpull.php", function(data) {
-            var myresults = data.result;
+
+            if (data.output) {
+
+                // form up our status message
+                var color = "lightgray";
+                var statushtml = "<p class=\"normal-italic\" style=\"margin-left: 40px; margin-bottom: 10px;\"><mark style=\"background-color: " + color + ";\">" + data.output + "</mark></p>";
+
+                // Append our status to the sync status element.
+                document.getElementById("syncup-status").innerHTML += statushtml;
+            }
+
         });
     }
 
@@ -2024,10 +2034,13 @@
 
         $.get("syncconfiguration.php", function(data) {
 
+            var ts = new Date();
+            var tmhtml = "<p class=\"normal-italic\">Sync Attempt: " + ts.toLocaleString() + "</p>"
             var color = (data.result > 0 ? "lightgreen" : "yellow");
-            var statushtml = "<mark style=\"background-color: " + color + ";\">" + data.error + "</mark>";
+            var statushtml = "<p class=\"normal-italic\" style=\"margin-left: 40px;\"><mark style=\"background-color: " + color + ";\">" + data.error + "</mark></p>";
 
-            document.getElementById("syncup-status").innerHTML = statushtml;
+            // Append our new status message to the syncup status element
+            document.getElementById("syncup-status").innerHTML += tmhtml + statushtml;
 
             // Attempt to perform git pull on eosstracker directory
             gitPullFiles();
@@ -2038,9 +2051,11 @@
             // Refresh all data on the page
             refreshPage();
 
-            setTimeout(function() {
+            // Don't clear the history of syncs (until the user reloads the page...obviously).
+            /*setTimeout(function() {
                 document.getElementById("syncup-status").innerHTML = "";
-            }, 3000);
+            }, 10000);
+            */
 
         });
     }

--- a/www/gitpull.php
+++ b/www/gitpull.php
@@ -32,5 +32,18 @@
     $gitpull_script = "/eosstracker/sbin/gitpullupdate.bash";
 
     $output = shell_exec('sudo -H -u eosstracker ' . $gitpull_script);
-    printf ("%s", $output);
+    if ($output) {
+        // If there was output from the command, the strip off newlines and carrage returns. 
+        $output = str_replace("\n", "", $output);
+        $output = str_replace("\r", "", $output);
+    }
+    else {
+        $output = "Unable to run 'git pull'";
+    }
+
+    // form up a JSON structure to send back to the client
+    $json = array("output" => $output);
+
+    // print out our JSON
+    printf ("%s", json_encode($json));
 ?>

--- a/www/gitpull.php
+++ b/www/gitpull.php
@@ -31,19 +31,26 @@
     
     $gitpull_script = "/eosstracker/sbin/gitpullupdate.bash";
 
-    $output = shell_exec('sudo -H -u eosstracker ' . $gitpull_script);
-    if ($output) {
-        // If there was output from the command, the strip off newlines and carrage returns. 
-        $output = str_replace("\n", "", $output);
-        $output = str_replace("\r", "", $output);
+    try {
+        $output = shell_exec('sudo -H -u eosstracker ' . $gitpull_script);
+        if ($output) {
+            // If there was output from the command, the strip off newlines and carrage returns. 
+            $output = str_replace("\n", "", $output);
+            $output = str_replace("\r", "", $output);
+        }
+        else {
+            $output = "Unable to run 'git pull'";
+        }
+
+        // form up a JSON structure to send back to the client
+        $json = array("output" => $output);
+
+        // print out our JSON
+        printf ("%s", json_encode($json));
     }
-    else {
-        $output = "Unable to run 'git pull'";
+    catch (Exception $e) {
+        $json = array("output" => $e->getMessage());
+        printf ("%s", json_encode($json));
     }
 
-    // form up a JSON structure to send back to the client
-    $json = array("output" => $output);
-
-    // print out our JSON
-    printf ("%s", json_encode($json));
 ?>


### PR DESCRIPTION
Edits to allow a JSON message to be returned from the ```/eosstracker/www/gitpull.php``` file.  That JSON is then used to create a formatted message to the user on the Setup web page (via ```/eosstracker/www/common/setup.js```).

Sync up attempts now stay visible on the Setup page (next to that Synchronize button) ...until the user reloads the page, obviously.